### PR TITLE
Add FishBody softbody scene

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -1,0 +1,37 @@
+[gd_scene format=3]
+
+[node name="FishBody" type="Node2D"]
+script = ExtResource("res://scripts/entities/fish_body.gd")
+
+[node name="segment_0" type="RigidBody2D" parent="."]
+position = Vector2(0, 0)
+
+[node name="segment_1" type="RigidBody2D" parent="."]
+position = Vector2(-20, 0)
+
+[node name="segment_2" type="RigidBody2D" parent="."]
+position = Vector2(-40, 0)
+
+[node name="segment_3" type="RigidBody2D" parent="."]
+position = Vector2(-60, 0)
+
+[node name="joint_1" type="DampedSpringJoint2D" parent="."]
+node_a = NodePath("segment_0")
+node_b = NodePath("segment_1")
+length = 20.0
+stiffness = 8.0
+damping = 0.7
+
+[node name="joint_2" type="DampedSpringJoint2D" parent="."]
+node_a = NodePath("segment_1")
+node_b = NodePath("segment_2")
+length = 20.0
+stiffness = 8.0
+damping = 0.7
+
+[node name="joint_3" type="DampedSpringJoint2D" parent="."]
+node_a = NodePath("segment_2")
+node_b = NodePath("segment_3")
+length = 20.0
+stiffness = 8.0
+damping = 0.7

--- a/scripts/entities/fish_body.gd
+++ b/scripts/entities/fish_body.gd
@@ -1,15 +1,66 @@
 ###############################################################
 # scripts/entities/fish_body.gd
-# Key funcs/classes: \u2022 FishBody – soft-body generator stub
+# Key funcs/classes: \u2022 FishBody – soft-body fish controller
 # Critical consts    \u2022 NONE
 ###############################################################
 
 class_name FishBody
 extends Node2D
 
+@export var spring_stiffness: float = 8.0
+@export var spring_damping: float = 0.7
+@export var segment_length: float = 20.0
+
 var soft_body_params: Dictionary
+var segments: Array = []
+var joints: Array = []
 
 
 func _ready() -> void:
-    # TODO: build soft-body segments using soft_body_params
-    pass
+    if soft_body_params:
+        _build_segments()
+    else:
+        _collect_existing()
+    _apply_joint_params()
+
+
+func _build_segments() -> void:
+    var node_count: int = soft_body_params.get("node_count", 4)
+    var masses: Array = soft_body_params.get("masses", [])
+
+    for i in range(node_count):
+        var seg := RigidBody2D.new()
+        seg.name = "segment_%d" % i
+        seg.position = Vector2(-i * segment_length, 0)
+        if i < masses.size():
+            seg.mass = float(masses[i])
+        add_child(seg)
+        segments.append(seg)
+        if i > 0:
+            var joint := DampedSpringJoint2D.new()
+            joint.name = "joint_%d" % i
+            joint.node_a = NodePath("segment_%d" % (i - 1))
+            joint.node_b = NodePath(seg.name)
+            joint.length = segment_length
+            add_child(joint)
+            joints.append(joint)
+
+
+func _collect_existing() -> void:
+    for child in get_children():
+        if child is RigidBody2D:
+            segments.append(child)
+        elif child is DampedSpringJoint2D:
+            joints.append(child)
+
+
+func _apply_joint_params() -> void:
+    for joint in joints:
+        joint.stiffness = spring_stiffness
+        joint.damping = spring_damping
+
+
+func apply_steering_force(force: Vector2) -> void:
+    if segments.size() > 0:
+        var head: RigidBody2D = segments[0]
+        head.apply_central_force(force)


### PR DESCRIPTION
## Summary
- add `FishBody.tscn` with a chain of `RigidBody2D` segments
- implement `FishBody` script to build segments, manage joints and apply steering force

## Testing
- `godot --headless --editor --import --quit --path .`
- `godot --headless --check-only --quit --path .`
- `dotnet build > /tmp/dotnet_build.log`
- `godot --headless -s res://tests/run_tests.gd`


------
https://chatgpt.com/codex/tasks/task_e_685c7197e7c4832987d1ef51be9d4dcd