### PR TITLE
Fix FishBody parse errors

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -1,7 +1,4 @@
 [gd_scene format=3]
-[ext_resource path="res://scripts/entities/fish_body.gd" type="Script" id=1]R[ext_resource path="res://sprites/placeholder.png" type="Texture2D" id=2]RR
-[ext_resource path="res://scripts/entities/fish_body.gd" type="Script" id=1]
-[ext_resource path="res://sprites/placeholder.png" type="Texture2D" id=2]
 
 [ext_resource path="res://scripts/entities/fish_body.gd" type="Script" id=1]
 [ext_resource path="res://sprites/placeholder.png" type="Texture2D" id=2]
@@ -34,6 +31,13 @@ damping = 0.7
 [node name="joint_2" type="DampedSpringJoint2D" parent="."]
 node_a = NodePath("segment_1")
 node_b = NodePath("segment_2")
+length = 20.0
+stiffness = 8.0
+damping = 0.7
+
+[node name="joint_3" type="DampedSpringJoint2D" parent="."]
+node_a = NodePath("segment_2")
+node_b = NodePath("segment_3")
 length = 20.0
 stiffness = 8.0
 damping = 0.7

--- a/scripts/entities/fish_body.gd
+++ b/scripts/entities/fish_body.gd
@@ -22,12 +22,14 @@ var soft_body_params: Dictionary
 var segments: Array = []
 var joints: Array = []
 
+
 func _ready() -> void:
     if soft_body_params:
         _build_segments()
     else:
         _collect_existing()
     _apply_joint_params()
+
 
 func _build_segments() -> void:
     var node_count: int = soft_body_params.get("node_count", 4)
@@ -48,6 +50,7 @@ func _build_segments() -> void:
             add_child(joint)
             joints.append(joint)
 
+
 func _collect_existing() -> void:
     for child in get_children():
         if child is RigidBody2D:
@@ -55,26 +58,31 @@ func _collect_existing() -> void:
         elif child is DampedSpringJoint2D:
             joints.append(child)
 
+
 func _apply_joint_params() -> void:
     for joint in joints:
         joint.stiffness = spring_stiffness
         joint.damping = spring_damping
+
 
 func apply_steering_force(force: Vector2) -> void:
     if segments.size() > 0:
         var head: RigidBody2D = segments[0]
         head.apply_central_force(force)
 
+
 func _physics_process(_delta: float) -> void:
     _update_depth_visuals()
     _clamp_position()
 
+
 func _update_depth_visuals() -> void:
-    var t := clamp((tank_size.z - z_depth) / tank_size.z, 0.0, 1.0)
-    var sc := lerp(MIN_SCALE, MAX_SCALE, t)
+    var t: float = clamp((tank_size.z - z_depth) / tank_size.z, 0.0, 1.0)
+    var sc: float = lerp(MIN_SCALE, MAX_SCALE, t)
     scale = Vector2(sc, sc)
-    var a := lerp(MIN_ALPHA, MAX_ALPHA, t)
+    var a: float = lerp(MIN_ALPHA, MAX_ALPHA, t)
     modulate.a = a
+
 
 func _clamp_position() -> void:
     global_position.x = clamp(global_position.x, 0.0, tank_size.x)


### PR DESCRIPTION
## Summary
- fix variable declarations in fish_body.gd to avoid Variant inference
- clean FishBody.tscn to remove corrupted ext_resource entries

## Testing
- `godot --headless --editor --import --quit --path .`
- `godot --headless --check-only --quit --path .`
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_685cbb167bd883299ca1d9529fd20f21