### PR TITLE
Fix missing shapes in FishBody

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -12,14 +12,34 @@ texture = ExtResource(2)
 [node name="segment_0" type="RigidBody2D" parent="."]
 position = Vector2(0, 0)
 
+[node name="shape" type="CollisionShape2D" parent="segment_0"]
+shape = CircleShape2D {
+    radius = 10.0
+}
+
 [node name="segment_1" type="RigidBody2D" parent="."]
 position = Vector2(-20, 0)
+
+[node name="shape" type="CollisionShape2D" parent="segment_1"]
+shape = CircleShape2D {
+    radius = 10.0
+}
 
 [node name="segment_2" type="RigidBody2D" parent="."]
 position = Vector2(-40, 0)
 
+[node name="shape" type="CollisionShape2D" parent="segment_2"]
+shape = CircleShape2D {
+    radius = 10.0
+}
+
 [node name="segment_3" type="RigidBody2D" parent="."]
 position = Vector2(-60, 0)
+
+[node name="shape" type="CollisionShape2D" parent="segment_3"]
+shape = CircleShape2D {
+    radius = 10.0
+}
 
 [node name="joint_1" type="DampedSpringJoint2D" parent="."]
 node_a = NodePath("segment_0")

--- a/scripts/entities/fish_body.gd
+++ b/scripts/entities/fish_body.gd
@@ -40,6 +40,12 @@ func _build_segments() -> void:
         seg.position = Vector2(-i * segment_length, 0)
         if i < masses.size():
             seg.mass = float(masses[i])
+        var col := CollisionShape2D.new()
+        var circle := CircleShape2D.new()
+        circle.radius = segment_length / 2.0
+        col.shape = circle
+        seg.add_child(col)
+        segments.append(seg)
         add_child(seg)
         if i > 0:
             var joint := DampedSpringJoint2D.new()
@@ -55,6 +61,12 @@ func _collect_existing() -> void:
     for child in get_children():
         if child is RigidBody2D:
             segments.append(child)
+            if child.get_node_or_null("CollisionShape2D") == null:
+                var col := CollisionShape2D.new()
+                var circle := CircleShape2D.new()
+                circle.radius = segment_length / 2.0
+                col.shape = circle
+                child.add_child(col)
         elif child is DampedSpringJoint2D:
             joints.append(child)
 


### PR DESCRIPTION
## Summary
- add `CollisionShape2D` nodes in `FishBody.tscn`
- ensure new or existing fish segments get a `CollisionShape2D`

## Testing
- `godot --headless --editor --import --quit --path .`
- `godot --headless --check-only --quit --path .`
- `godot --headless -s res://tests/run_tests.gd`

------
https://chatgpt.com/codex/tasks/task_e_685cc2407ef08329bb740a9723ac07f5