### PR TITLE
Fix FishBody scene parse error

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -1,7 +1,19 @@
-[gd_scene load_steps=3 format=3 uid="uid://drtf5gn5rllhs"]
+[gd_scene load_steps=7 format=3 uid="uid://drtf5gn5rllhs"]
 
 [ext_resource type="Script" path="res://scripts/entities/fish_body.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://btfhgbmt5csqu" path="res://sprites/placeholder.png" id="2"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 10.0
+
+[sub_resource type="CircleShape2D" id="2"]
+radius = 10.0
+
+[sub_resource type="CircleShape2D" id="3"]
+radius = 10.0
+
+[sub_resource type="CircleShape2D" id="4"]
+radius = 10.0
 
 [node name="FishBody" type="Node2D"]
 script = ExtResource("1")
@@ -12,33 +24,25 @@ texture = ExtResource("2")
 [node name="segment_0" type="RigidBody2D" parent="."]
 
 [node name="shape" type="CollisionShape2D" parent="segment_0"]
-shape = CircleShape2D {
-    radius = 10.0
-}
+shape = SubResource("1")
 
 [node name="segment_1" type="RigidBody2D" parent="."]
 position = Vector2(-20, 0)
 
 [node name="shape" type="CollisionShape2D" parent="segment_1"]
-shape = CircleShape2D {
-    radius = 10.0
-}
+shape = SubResource("2")
 
 [node name="segment_2" type="RigidBody2D" parent="."]
 position = Vector2(-40, 0)
 
 [node name="shape" type="CollisionShape2D" parent="segment_2"]
-shape = CircleShape2D {
-    radius = 10.0
-}
+shape = SubResource("3")
 
 [node name="segment_3" type="RigidBody2D" parent="."]
 position = Vector2(-60, 0)
 
 [node name="shape" type="CollisionShape2D" parent="segment_3"]
-shape = CircleShape2D {
-    radius = 10.0
-}
+shape = SubResource("4")
 
 [node name="joint_1" type="DampedSpringJoint2D" parent="."]
 node_a = NodePath("segment_0")


### PR DESCRIPTION
## Summary
- update `FishBody.tscn` to use Godot 4 sub_resource syntax

## Testing
- `godot --headless --editor --import --quit --path .`
- `godot --headless --check-only --quit --path .`
- `dotnet build` *(fails: no project)*
- `godot --headless --quit --path . --verbose res://scenes/FishBody.tscn`

------
https://chatgpt.com/codex/tasks/task_e_685cc9177094832980a07d1650b0fc58