### PR TITLE
Fix FishBody joints and remove test warnings

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -12,7 +12,7 @@
 [sub_resource type="CircleShape2D" id="4"]
 
 [node name="FishBody" type="Node2D"]
-position = Vector2(555, 543)
+position = Vector2(0, 0)
 script = ExtResource("1")
 
 [node name="Sprite" type="Sprite2D" parent="."]
@@ -42,22 +42,22 @@ position = Vector2(-60, 0)
 shape = SubResource("4")
 
 [node name="joint_1" type="DampedSpringJoint2D" parent="."]
-node_a = NodePath("segment_0")
-node_b = NodePath("segment_1")
+node_a = NodePath("../segment_0")
+node_b = NodePath("../segment_1")
 length = 20.0
 stiffness = 8.0
 damping = 0.7
 
 [node name="joint_2" type="DampedSpringJoint2D" parent="."]
-node_a = NodePath("segment_1")
-node_b = NodePath("segment_2")
+node_a = NodePath("../segment_1")
+node_b = NodePath("../segment_2")
 length = 20.0
 stiffness = 8.0
 damping = 0.7
 
 [node name="joint_3" type="DampedSpringJoint2D" parent="."]
-node_a = NodePath("segment_2")
-node_b = NodePath("segment_3")
+node_a = NodePath("../segment_2")
+node_b = NodePath("../segment_3")
 length = 20.0
 stiffness = 8.0
 damping = 0.7

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -34,4 +34,5 @@ func test_spatial_hash_basic() -> bool:
     var success := res.has("a") and res.has("b") and not res.has("c")
     if not success:
         push_error("SpatialHash2D basic query failed: %s" % [res])
+    grid.queue_free()
     return success


### PR DESCRIPTION
## Summary
- connect spring joints to fish segments properly
- reset FishBody position to origin
- free SpatialHash2D in tests to avoid shutdown warnings

## Testing
- `godot --headless --editor --import --quit --path .`
- `godot --headless --check-only --quit --path .`
- `godot --headless -s res://tests/run_tests.gd`


------
https://chatgpt.com/codex/tasks/task_e_685cd3a6579c8329a6c029e0e4fcb3c2