### PR TITLE
Add debug logging and headless benchmark

### DIFF
--- a/scripts/benchmark/headless_benchmark.gd
+++ b/scripts/benchmark/headless_benchmark.gd
@@ -1,0 +1,32 @@
+###############################################################
+# scripts/benchmark/headless_benchmark.gd
+# Key Classes      • HeadlessBenchmark – small headless run for velocity debug
+# Key Functions    • _initialize() – spawn one fish and simulate
+# Dependencies     • FishBody.tscn, fish_agent.gd, SpatialHash2D.gd
+###############################################################
+
+extends SceneTree
+
+const FishScene = preload("res://scenes/FishBody.tscn")
+const FishAgent = preload("res://scripts/fish/fish_agent.gd")
+const SpatialHash2D = preload("res://scripts/boids/SpatialHash2D.gd")
+
+@export var steps: int = 120
+
+
+func _initialize() -> void:
+    var fish: Node2D = FishScene.instantiate()
+    get_root().add_child(fish)
+    var agent := FishAgent.new()
+    fish.add_child(agent)
+    agent.velocity = Vector2(10, 0)
+    agent.debug_log = true
+    agent.setup(SpatialHash2D.new(10.0), agent.params)
+    await run_simulation()
+    quit()
+
+
+func run_simulation() -> void:
+    for i in range(steps):
+        await physics_frame
+    print("benchmark complete")

--- a/scripts/benchmark/headless_benchmark.gd.uid
+++ b/scripts/benchmark/headless_benchmark.gd.uid
@@ -1,0 +1,1 @@
+uid://bbjivlvy2wenq

--- a/scripts/entities/fish_body.gd
+++ b/scripts/entities/fish_body.gd
@@ -20,8 +20,9 @@ const MAX_ALPHA := 1.0
 #  EXPORTED TUNABLES
 # ------------------------------------------------------------------
 @export var spring_stiffness: float = 8.0
-@export var spring_damping: float = 0.7
+@export var spring_damping: float = 1.0
 @export var segment_length: float = 20.0
+@export var body_linear_damp: float = 1.0
 @export_range(0.0, 5.5) var z_depth: float = 0.0
 @export var tank_size: Vector3 = Vector3(16.0, 9.0, 5.5)
 
@@ -62,6 +63,8 @@ func _build_segments() -> void:
         var seg := RigidBody2D.new()
         seg.name = "segment_%d" % i
         seg.position = Vector2(-i * segment_length, 0)
+        seg.linear_damp = body_linear_damp
+        seg.angular_damp = body_linear_damp
         if i < masses.size():
             seg.mass = float(masses[i])
 
@@ -88,6 +91,8 @@ func _collect_existing() -> void:
     for child in get_children():
         if child is RigidBody2D:
             segments.append(child)
+            child.linear_damp = body_linear_damp
+            child.angular_damp = body_linear_damp
             if child.get_node_or_null("CollisionShape2D") == null:
                 var col := CollisionShape2D.new()
                 var circle := CircleShape2D.new()
@@ -120,6 +125,13 @@ func set_head_velocity(v: Vector2) -> void:
     if segments.size() > 0:
         var head: RigidBody2D = segments[0]
         head.linear_velocity = v
+
+
+func get_head_velocity() -> Vector2:
+    if segments.size() > 0:
+        var head: RigidBody2D = segments[0]
+        return head.linear_velocity
+    return Vector2.ZERO
 
 
 # ------------------------------------------------------------------

--- a/scripts/fish/fish_agent.gd
+++ b/scripts/fish/fish_agent.gd
@@ -5,21 +5,24 @@
 class_name FishAgent
 extends Node
 
-const FishBody         = preload("res://scripts/entities/fish_body.gd")
-const SpatialHash2D    = preload("res://scripts/boids/SpatialHash2D.gd")
-const FlockParameters  = preload("res://scripts/boids/flock_parameters.gd")
+const FishBody = preload("res://scripts/entities/fish_body.gd")
+const SpatialHash2D = preload("res://scripts/boids/SpatialHash2D.gd")
+const FlockParameters = preload("res://scripts/boids/flock_parameters.gd")
 
-@export var max_speed:       float = 15.0   # real px / sec now
-@export var max_force:       float =  .9
-@export var neighbor_radius: float =  4.0
-@export var wander_strength: float =   0.3   # jitter amount
+@export var max_speed: float = 15.0  # real px / sec now
+@export var max_force: float = .9
+@export var neighbor_radius: float = 4.0
+@export var wander_strength: float = 0.3  # jitter amount
+@export var debug_log: bool = false
 
-var velocity:     Vector2 = Vector2.ZERO
+var velocity: Vector2 = Vector2.ZERO
 var acceleration: Vector2 = Vector2.ZERO
-var fish:         FishBody
+var fish: FishBody
 var spatial_hash: SpatialHash2D
-var params:       FlockParameters = FlockParameters.new()
+var params: FlockParameters = FlockParameters.new()
 var _rng := RandomNumberGenerator.new()
+var _boid_accel: Vector2 = Vector2.ZERO
+var _wander_accel: Vector2 = Vector2.ZERO
 
 
 func _ready() -> void:
@@ -29,7 +32,7 @@ func _ready() -> void:
 
 func setup(hash: SpatialHash2D, p_params: FlockParameters) -> void:
     spatial_hash = hash
-    params       = p_params
+    params = p_params
 
 
 func _physics_process(delta: float) -> void:
@@ -52,6 +55,22 @@ func _physics_process(delta: float) -> void:
 
     # *** no forces — we write the velocity directly ***
     fish.set_head_velocity(velocity)
+
+    if debug_log:
+        var phys_v := fish.get_head_velocity()
+        var injected := phys_v - velocity
+        print(
+            (
+                "frame %d vel=%.2f boid=%.2f wander=%.2f injected=%.2f"
+                % [
+                    Engine.get_physics_frames(),
+                    phys_v.length(),
+                    _boid_accel.length(),
+                    _wander_accel.length(),
+                    injected.length()
+                ]
+            )
+        )
 
     acceleration = Vector2.ZERO
 
@@ -93,11 +112,13 @@ func _apply_boid_rules(neighbors: Array) -> void:
     if steer.length() > max_force:
         steer = steer.normalized() * max_force
     acceleration += steer
+    _boid_accel = steer
 
 
 # ----------------------- RANDOM WANDER -------------------------------------
 func _apply_wander() -> void:
-    acceleration += Vector2(
-        _rng.randf_range(-1.0, 1.0),
-        _rng.randf_range(-1.0, 1.0)
-    ) * wander_strength
+    var jitter := (
+        Vector2(_rng.randf_range(-1.0, 1.0), _rng.randf_range(-1.0, 1.0)) * wander_strength
+    )
+    acceleration += jitter
+    _wander_accel = jitter

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -8,6 +8,8 @@ extends SceneTree
 
 const SpatialHash2D = preload("res://scripts/boids/SpatialHash2D.gd")
 const FishBody = preload("res://scripts/entities/fish_body.gd")
+const FishBodyScene = preload("res://scenes/FishBody.tscn")
+const FishAgent = preload("res://scripts/fish/fish_agent.gd")
 
 
 func _initialize() -> void:
@@ -24,6 +26,7 @@ func run_all() -> bool:
     var ok := true
     ok = ok and test_spatial_hash_basic()
     ok = ok and await test_fish_movement()
+    ok = ok and await test_energy_dissipation()
     return ok
 
 
@@ -41,7 +44,7 @@ func test_spatial_hash_basic() -> bool:
 
 
 func test_fish_movement() -> bool:
-    var scene: PackedScene = load("res://scenes/FishBody.tscn")
+    var scene: PackedScene = FishBodyScene
     var fish: FishBody = scene.instantiate()
     get_root().add_child(fish)
     await physics_frame
@@ -55,3 +58,22 @@ func test_fish_movement() -> bool:
         push_error("segment_0 did not move: %s -> %s" % [start, seg.global_position])
     fish.queue_free()
     return moved
+
+
+func test_energy_dissipation() -> bool:
+    var scene: PackedScene = FishBodyScene
+    var fish: FishBody = scene.instantiate()
+    get_root().add_child(fish)
+    var agent := FishAgent.new()
+    fish.add_child(agent)
+    agent.velocity = Vector2(20, 0)
+    agent.setup(SpatialHash2D.new(10.0), agent.params)
+    var last_speed := 0.0
+    for i in range(120):
+        await physics_frame
+        last_speed = fish.get_head_velocity().length()
+    fish.queue_free()
+    if last_speed > fish.max_safe_speed:
+        push_error("speed exceeded: %.2f" % last_speed)
+        return false
+    return true


### PR DESCRIPTION
## Summary
- add optional debug logging to `FishAgent` and expose boid/wander energy
- clamp soft body spring energy by increasing damping and linear damp
- provide helper `get_head_velocity` in `FishBody`
- add headless benchmark scene
- extend tests with energy dissipation check and share constants

## Testing
- `godot --headless --editor --import --quit --path .`
- `godot --headless --check-only --quit --path .`
- `dotnet build`
- `godot --headless -s res://tests/run_tests.gd`
- `godot --headless -s res://scripts/benchmark/headless_benchmark.gd`

------
https://chatgpt.com/codex/tasks/task_e_685d64cb8d3083299f8abfb8a53c1018