### PR TITLE
Fix parse error in FishBody scene

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -1,5 +1,4 @@
 [gd_scene load_steps=8 format=3 uid="uid://drtf5gn5rllhs"]
-
 [ext_resource type="Script" uid="uid://2j66gx3em4vl" path="res://scripts/entities/fish_body.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://btfhgbmt5csqu" path="res://sprites/placeholder.png" id="3"]
 [ext_resource type="Material" path="res://materials/fish_lit.tres" id="4"]


### PR DESCRIPTION
## Summary
- remove empty line after the scene header in `FishBody.tscn`

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore scripts/dummy/DummyLibrary.csproj --nologo`
- `dotnet build --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_685eb68ce1a483299dbec285e228cb70