### PR TITLE
Fix FishBody scene parse error

### DIFF
--- a/scenes/FishBody.tscn
+++ b/scenes/FishBody.tscn
@@ -1,8 +1,7 @@
 [gd_scene load_steps=8 format=3 uid="uid://drtf5gn5rllhs"]
-
 [ext_resource type="Script" uid="uid://2j66gx3em4vl" path="res://scripts/entities/fish_body.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://btfhgbmt5csqu" path="res://sprites/placeholder.png" id="3"]
-[ext_resource type="Material" path="res://materials/fish_lit.tres" id="4"]
+[ext_resource type="Texture2D" uid="uid://btfhgbmt5csqu" path="res://sprites/placeholder.png" id="2"]
+[ext_resource type="Material" path="res://materials/fish_lit.tres" id="3"]
 
 [sub_resource type="CircleShape2D" id="1"]
 
@@ -16,8 +15,8 @@
 script = ExtResource("1")
 
 [node name="Sprite" type="Sprite2D" parent="."]
-material = ExtResource("4")
-texture = ExtResource("3")
+material = ExtResource("3")
+texture = ExtResource("2")
 
 [node name="segment_0" type="RigidBody2D" parent="."]
 
@@ -62,3 +61,4 @@ node_b = NodePath("../segment_3")
 length = 20.0
 stiffness = 8.0
 damping = 0.7
+


### PR DESCRIPTION
## Summary
- fix missing resource IDs in `FishBody.tscn`
- ensure sprite references correct resources

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_685eb68ce1a483299dbec285e228cb70