### PR TITLE
Initialize fishtank structure and shape generator

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -8,3 +8,5 @@
 - Added ignore rules for temporary files inside `ui/` and `tools/`.
 - Created `scripts/data/` with resource classes for core data structures.
 - Implemented `ArchetypeLoader` with placeholder texture fallback and loaded in `FishTank`.
+- Added `art/shape_generator.gd` to create ellipse and triangle placeholders.
+- Updated loader and JSON to use generated textures when sprites are missing.

--- a/fishtank/README.md
+++ b/fishtank/README.md
@@ -17,5 +17,7 @@ Both `ui/` and `tools/` are created empty for now and ready for new scenes and e
 
 ## Adding New Archetypes
 1. Create an entry in `data/archetypes.json`.
-2. Provide any required placeholder art in `art/`.
+2. Provide any required placeholder art in `art/`. When nothing is supplied,
+   run `godot --headless -s res://art/shape_generator.gd` to create default
+   ellipse and triangle textures.
 3. Extend scripts to support custom behavior.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -8,5 +8,6 @@
 
 - [x] Implement FishArchetype parsing from JSON.
 - [x] Integrate ArchetypeLoader in FishTank scene.
+- [x] Create ShapeGenerator script for ellipse/triangle placeholders.
 - Add boid behavior system.
 - Create UI for spawning fish.

--- a/fishtank/art/shape_generator.gd
+++ b/fishtank/art/shape_generator.gd
@@ -1,0 +1,46 @@
+###############################################################
+# fishtank/art/shape_generator.gd
+# Key Classes      • ShapeGenerator – generates placeholder textures
+# Key Functions    • SG_generate_shapes_IN() – writes ellipse and triangle images
+# Dependencies     • None
+# Last Major Rev   • 24-06-30 – initial creation
+###############################################################
+# gdlint:disable = function-variable-name,function-name,loop-variable-name
+
+class_name ShapeGenerator
+extends Node
+
+
+func SG_generate_shapes_IN() -> void:
+    var SG_ellipse_image_UP := _SG_create_ellipse_IN(64, 32, Color.WHITE)
+    SG_ellipse_image_UP.save_png("res://art/ellipse_placeholder.png")
+    var SG_triangle_image_UP := _SG_create_triangle_IN(64, 64, Color.WHITE)
+    SG_triangle_image_UP.save_png("res://art/triangle_placeholder.png")
+
+
+func _SG_create_ellipse_IN(width: int, height: int, color: Color) -> Image:
+    var SG_img_UP := Image.create(width, height, false, Image.FORMAT_RGBA8)
+    SG_img_UP.fill(Color.TRANSPARENT)
+    var SG_rx_UP := width / 2.0
+    var SG_ry_UP := height / 2.0
+    for SG_y_IN in range(height):
+        for SG_x_IN in range(width):
+            var SG_dx_UP: float = (SG_x_IN - SG_rx_UP + 0.5) / SG_rx_UP
+            var SG_dy_UP: float = (SG_y_IN - SG_ry_UP + 0.5) / SG_ry_UP
+            if SG_dx_UP * SG_dx_UP + SG_dy_UP * SG_dy_UP <= 1.0:
+                SG_img_UP.set_pixel(SG_x_IN, SG_y_IN, color)
+    return SG_img_UP
+
+
+func _SG_create_triangle_IN(width: int, height: int, color: Color) -> Image:
+    var SG_img_UP := Image.create(width, height, false, Image.FORMAT_RGBA8)
+    SG_img_UP.fill(Color.TRANSPARENT)
+    var SG_center_UP := width / 2.0
+    for SG_y_IN in range(height):
+        var SG_ratio_UP: float = float(SG_y_IN) / max(height - 1, 1)
+        var SG_half_width_UP: float = (width * SG_ratio_UP) / 2.0
+        for SG_x_IN in range(width):
+            if abs(SG_x_IN - SG_center_UP) <= SG_half_width_UP:
+                SG_img_UP.set_pixel(SG_x_IN, SG_y_IN, color)
+    return SG_img_UP
+# gdlint:enable = function-variable-name,function-name,loop-variable-name

--- a/fishtank/art/shape_generator.gd.uid
+++ b/fishtank/art/shape_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://bu4ne7cbw6vqc

--- a/fishtank/data/archetypes.json
+++ b/fishtank/data/archetypes.json
@@ -2,7 +2,7 @@
     {
         "name": "Flocker",
         "species_list": [],
-        "placeholder_texture": "res://art/placeholder_fish.png",
+        "placeholder_texture": "",
         "base_color": "#FFFFFF"
     }
 ]

--- a/fishtank/project.godot
+++ b/fishtank/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="FakeyFishTank"
 run/main_scene="res://scenes/FishTank.tscn"
-config/features=PackedStringArray("4.4")
+config/features=PackedStringArray("4.4.1")
 run/max_fps=60
 
 [debug]

--- a/fishtank/scripts/data/archetype_loader.gd
+++ b/fishtank/scripts/data/archetype_loader.gd
@@ -16,7 +16,13 @@ var AL_default_texture_IN: Texture2D
 
 
 func _init() -> void:
-    AL_default_texture_IN = preload("res://art/placeholder_fish.png")
+    var AL_shape_gen_UP: Node = load("res://art/shape_generator.gd").new()
+    AL_shape_gen_UP.SG_generate_shapes_IN()
+    var AL_default_path_UP := "res://art/ellipse_placeholder.png"
+    if ResourceLoader.exists(AL_default_path_UP):
+        AL_default_texture_IN = load(AL_default_path_UP)
+    else:
+        AL_default_texture_IN = preload("res://art/placeholder_fish.png")
 
 
 func AL_load_archetypes_IN(json_path: String) -> Array[FishArchetype]:


### PR DESCRIPTION
## Summary
- init Godot 4.4.1 project settings for `fishtank`
- add ellipse/triangle placeholder generator
- load generated textures in archetype loader
- document generator usage and update todos

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6860357a3a4483299432d6f72169cbcb