### PR TITLE
Fix duplicate assembly metadata

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -2,3 +2,4 @@
 
 ## [Unreleased]
 - Initial repository documentation files.
+- Disabled auto-generated assembly metadata to avoid duplicate attributes.

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,3 @@
 # TODO
 - Set up documentation for root workspace.
+- Investigate and resolve duplicate assembly attribute errors.

--- a/fishtank/FishTank.csproj
+++ b/fishtank/FishTank.csproj
@@ -3,5 +3,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 </Project>

--- a/scripts/dummy/DummyLibrary.csproj
+++ b/scripts/dummy/DummyLibrary.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- disable GenerateAssemblyInfo in C# projects
- note the fix in docs

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --no-restore --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6860411e8f2083298c73fa5d6497fafa