### PR TITLE
Fix duplicate TargetFramework error

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -3,3 +3,5 @@
 ## [Unreleased]
 - Initial repository documentation files.
 - Disabled auto-generated assembly metadata to avoid duplicate attributes.
+- Added explicit `GenerateTargetFrameworkAttribute` property to fix duplicate
+  `TargetFramework` errors on some systems.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 # TODO
 - Set up documentation for root workspace.
-- Investigate and resolve duplicate assembly attribute errors.
+- [x] Investigate and resolve duplicate assembly attribute errors.

--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -11,3 +11,5 @@
 - Added `art/shape_generator.gd` to create ellipse and triangle placeholders.
 - Updated loader and JSON to use generated textures when sprites are missing.
 - Implemented `BoidSystem` with per-archetype weight overrides and basic flocking.
+- Added `GenerateTargetFrameworkAttribute` property in `FishTank.csproj` to avoid
+  duplicate attribute build errors.

--- a/fishtank/FishTank.csproj
+++ b/fishtank/FishTank.csproj
@@ -4,5 +4,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 </Project>

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -11,3 +11,4 @@
 - [x] Create ShapeGenerator script for ellipse/triangle placeholders.
 - [x] Add boid behavior system.
 - Create UI for spawning fish.
+- [x] Resolve duplicate TargetFramework build attribute.

--- a/scripts/dummy/DummyLibrary.csproj
+++ b/scripts/dummy/DummyLibrary.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- avoid duplicate TargetFramework attribute by disabling its generation
- document the fix in CHANGELOG and mark TODOs complete

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --no-restore --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_686156e9894c8329b95d4e9c201551a5