### PR TITLE
Fix boid scripts parse errors

### DIFF
--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -19,7 +19,6 @@ func _ready() -> void:
     set_process(true)
 
 
-func _process(delta: float) -> void:
-    _ = delta
+func _process(_delta: float) -> void:
     if BF_velocity_UP != Vector2.ZERO:
         rotation = BF_velocity_UP.angle()

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -30,7 +30,7 @@ func _ready() -> void:
         BS_fish_scene_IN = preload("res://scenes/BoidFish.tscn")
     if BS_environment_IN == null:
         var BS_parent_UP: Node = get_parent()
-        if BS_parent_UP != null and BS_parent_UP.has_variable("FT_environment_IN"):
+        if BS_parent_UP != null and BS_parent_UP is FishTank:
             BS_environment_IN = BS_parent_UP.FT_environment_IN
         else:
             BS_environment_IN = TankEnvironment.new()


### PR DESCRIPTION
## Summary
- fix `_process` unused parameter in `BoidFish`
- use type check instead of nonexistent `has_variable`

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686176d2a484832990aace14f22557da