### PR TITLE
Fix boid diff typing

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,3 +9,4 @@
   avoidance to keep fish inside the tank.
 - Boundaries now derive from the viewport and the placeholder Tank node was
   removed.
+- Fixed a parse error in `boid_system.gd` by explicitly typing `BS_diff_UP`.

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 - Set up documentation for root workspace.
 - [x] Investigate and resolve duplicate assembly attribute errors.
 - [ ] Polish boid group visuals and add unit tests for boundary logic.
+- [ ] Verify boid scripts compile without type inference errors.

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -102,7 +102,7 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             for BS_other_UP in BS_grid_SH[BS_key_UP]:
                 if BS_other_UP == fish:
                     continue
-                var BS_diff_UP := BS_other_UP.position - fish.position
+                var BS_diff_UP: Vector2 = BS_other_UP.position - fish.position
                 var BS_dist_UP: float = BS_diff_UP.length()
                 if BS_dist_UP < BS_neighbor_radius_IN:
                     BS_ali_UP += BS_other_UP.BF_velocity_UP


### PR DESCRIPTION
## Summary
- fix parse error by annotating BS_diff_UP as Vector2
- document the fix in CHANGE_LOG
- note follow-up todo for boid compilation checks

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6861a0680c8083298f48f2b8b4d3d1e2