### PR TITLE
Implement depth-based boids

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,3 +10,5 @@
 - Boundaries now derive from the viewport and the placeholder Tank node was
   removed.
 - Fixed type inference error in BoidSystem affecting build.
+- Added depth-based scaling and randomized z positions for boids.
+- Default population increased to over 50 fish across six groups.

--- a/TODO.md
+++ b/TODO.md
@@ -2,4 +2,5 @@
 - Set up documentation for root workspace.
 - [x] Investigate and resolve duplicate assembly attribute errors.
 - [ ] Polish boid group visuals and add unit tests for boundary logic.
+- [ ] Verify depth scaling across 6 fish groups with 50+ population.
 - [x] Resolve BoidSystem type inference error.

--- a/fishtank/scenes/FishTank.tscn
+++ b/fishtank/scenes/FishTank.tscn
@@ -9,6 +9,11 @@
 script = ExtResource("1")
 FT_environment_IN = SubResource("1")
 
+[node name="TankBounds" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.05, 0.05, 0.1, 0.2)
+
 [node name="BoidSystem" type="Node2D" parent="."]
 position = Vector2(640, 390)
 script = ExtResource("2")

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -1,18 +1,22 @@
 ###############################################################
 # fishtank/scripts/boids/boid_fish.gd
 # Key Classes      • BoidFish – minimal boid entity
-# Dependencies     • fish_archetype.gd
+# Dependencies     • fish_archetype.gd, tank_environment.gd
 # Last Major Rev   • 24-07-05 – initial creation
 ###############################################################
-# gdlint:disable = class-variable-name
+# gdlint:disable = class-variable-name,function-name,function-variable-name
 
 class_name BoidFish
 extends Node2D
+
+const TankEnvironment = preload("res://scripts/data/tank_environment.gd")
 
 var BF_velocity_UP: Vector2 = Vector2.ZERO
 var BF_archetype_IN: FishArchetype
 var BF_group_id_SH: int = 0
 var BF_isolated_timer_UP: float = 0.0
+var BF_depth_UP: float = 0.0
+var BF_environment_IN: TankEnvironment
 
 
 func _ready() -> void:
@@ -22,3 +26,16 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
     if BF_velocity_UP != Vector2.ZERO:
         rotation = BF_velocity_UP.angle()
+    if BF_environment_IN != null:
+        _BF_apply_depth_IN()
+
+
+func _BF_apply_depth_IN() -> void:
+    var BF_ratio_UP: float = clamp(
+        (BF_environment_IN.TE_size_IN.z - BF_depth_UP) / BF_environment_IN.TE_size_IN.z,
+        0.0,
+        1.0,
+    )
+    var BF_scale_UP: float = lerp(0.5, 1.0, BF_ratio_UP)
+    scale = Vector2.ONE * BF_scale_UP
+    modulate.a = lerp(0.4, 1.0, BF_ratio_UP)

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -17,7 +17,7 @@ extends Node2D
 @export var BS_neighbor_radius_IN: float = 80.0
 @export var BS_separation_distance_IN: float = 40.0
 @export var BS_environment_IN: TankEnvironment
-@export var BS_group_count_IN: int = 5
+@export var BS_group_count_IN: int = 6
 @export var BS_boundary_margin_IN: float = 1.0
 @export var BS_grid_cell_size_IN: float = 100.0
 
@@ -57,10 +57,19 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> void:
         var BS_bounds_UP: AABB = BS_environment_IN.TE_boundaries_SH
         var BS_center_UP := BS_bounds_UP.position + BS_bounds_UP.size / 2.0
         BS_fish_UP.position = Vector2(BS_center_UP.x, BS_center_UP.y)
+        BS_fish_UP.BF_depth_UP = (
+            BS_rng_UP
+            . randf_range(
+                0.0,
+                BS_environment_IN.TE_size_IN.z,
+            )
+        )
+        BS_fish_UP.BF_environment_IN = BS_environment_IN
     else:
         BS_fish_UP.position = Vector2(
             BS_rng_UP.randf_range(-50, 50), BS_rng_UP.randf_range(-30, 30)
         )
+        BS_fish_UP.BF_depth_UP = 0.0
     BS_fish_UP.BF_archetype_IN = arch
     BS_fish_UP.BF_group_id_SH = BS_rng_UP.randi_range(0, max(1, BS_group_count_IN) - 1)
     add_child(BS_fish_UP)
@@ -183,6 +192,13 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     BS_vel_UP = BS_vel_UP.limit_length(BS_config_IN.BC_max_speed_IN)
     fish.position += BS_vel_UP * delta
     fish.BF_velocity_UP = BS_vel_UP
+    if BS_environment_IN != null:
+        fish.BF_depth_UP += BS_rng_UP.randf_range(-20.0, 20.0) * delta
+        fish.BF_depth_UP = clamp(
+            fish.BF_depth_UP,
+            0.0,
+            BS_environment_IN.TE_size_IN.z,
+        )
 
 
 func _BS_get_weight_IN(arch: FishArchetype, field: String, default_val: float) -> float:

--- a/fishtank/scripts/data/boid_system_config.gd
+++ b/fishtank/scripts/data/boid_system_config.gd
@@ -23,8 +23,8 @@ Configurable constants controlling the default boid behavior parameters.
 @export var BC_default_wander_IN: float = 0.5
 @export var BC_max_speed_IN: float = 200.0
 @export var BC_max_force_IN: float = 50.0
-@export var BC_fish_count_min_IN: int = 3
-@export var BC_fish_count_max_IN: int = 15
+@export var BC_fish_count_min_IN: int = 50
+@export var BC_fish_count_max_IN: int = 60
 @export var BC_archetype_count_min_IN: int = 3
 @export var BC_archetype_count_max_IN: int = 5
 @export var BC_misc_params_SH: Dictionary = {}


### PR DESCRIPTION
## Summary
- expand boid system config for larger fish counts
- add 6 flock groups and randomized z depth for each fish
- update BoidFish to apply fake 3D scaling
- move fish in z while keeping within tank depth
- include TankBounds in FishTank scene

## Testing
- `gdlint fishtank/scripts/boids/boid_fish.gd fishtank/scripts/boids/boid_system.gd fishtank/scripts/data/boid_system_config.gd`
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore --nologo`
- `dotnet build --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6861aee12ac0832999e0131d72947d8f