### PR TITLE
Add FishBehavior enum and default fields

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -20,3 +20,5 @@
 - Removed placeholder `Tank` node and compute boundaries from viewport so
   fish stay within the visible tank.
 - Improved boid steering using spatial grid, separation distance, and wander.
+- Introduced `FishBehavior` enum and new behavior-related exports for `BoidFish`.
+  Updated `FishArchetype` with a matching `FA_behavior_IN` field.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -14,3 +14,4 @@
 - [x] Verify spawn location and boundary sanity checks for fish.
 - [x] Resolve duplicate TargetFramework build attribute.
 - [ ] Improve boid flocking with wander and spatial grid.
+- [x] Add FishBehavior enum and behavior fields to fish boids.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -2,6 +2,9 @@
 # fishtank/scripts/boids/boid_fish.gd
 # Key Classes      • BoidFish – minimal boid entity
 # Dependencies     • fish_archetype.gd, tank_environment.gd
+# Editor Exports   • BF_behavior_SH: FishBehavior
+#                   • BF_wander_phase_UP: float
+#                   • BF_target_depth_SH: float
 # Last Major Rev   • 24-07-05 – initial creation
 ###############################################################
 # gdlint:disable = class-variable-name,function-name,function-variable-name
@@ -9,7 +12,18 @@
 class_name BoidFish
 extends Node2D
 
+enum FishBehavior {
+    SCHOOL,
+    DART,
+    CURIOUS,
+    IDLE,
+}
+
 const TankEnvironment = preload("res://scripts/data/tank_environment.gd")
+
+@export var BF_behavior_SH: FishBehavior = FishBehavior.SCHOOL
+@export var BF_wander_phase_UP: float = 0.0
+@export var BF_target_depth_SH: float = 0.0
 
 var BF_velocity_UP: Vector2 = Vector2.ZERO
 var BF_archetype_IN: FishArchetype

--- a/fishtank/scripts/data/fish_archetype.gd
+++ b/fishtank/scripts/data/fish_archetype.gd
@@ -4,6 +4,7 @@
 # Key Functions    • N/A
 # Critical Consts  • None
 # Editor Exports   • FA_name_IN: String
+#                   • FA_behavior_IN: int
 # Dependencies     • None
 # Last Major Rev   • 24-06-28 – initial creation
 ###############################################################
@@ -15,6 +16,9 @@ extends Resource
 
 """
 Holds configuration data defining behaviors and visuals for a fish archetype.
+
+The `FA_behavior_IN` field specifies the default `FishBehavior` for fish using
+this archetype. Values correspond to the enum defined in `BoidFish`.
 """
 
 @export var FA_name_IN: String = ""
@@ -36,5 +40,6 @@ Holds configuration data defining behaviors and visuals for a fish archetype.
 @export var FA_chase_chance_IN: float = 0.0
 @export var FA_jump_chance_IN: float = 0.0
 @export var FA_rest_chance_IN: float = 0.0
+@export var FA_behavior_IN: int = 0
 @export var FA_special_notes_IN: String = ""
 # gdlint:enable = class-variable-name


### PR DESCRIPTION
## Summary
- add FishBehavior enum to BoidFish
- export behavior fields on BoidFish
- add FA_behavior_IN to FishArchetype
- document new fields in class comments
- note changes in CHANGELOG and TODO

## Testing
- `gdlint fishtank/scripts/boids/boid_fish.gd fishtank/scripts/data/fish_archetype.gd || true`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6861cac6e3248329950e2d680aa5e939