### PR TITLE
Fix shape generator directory creation

### DIFF
--- a/fishtank/art/shape_generator.gd
+++ b/fishtank/art/shape_generator.gd
@@ -15,7 +15,7 @@ const SG_ART_DIR := "res://art"
 
 func SG_generate_shapes_IN() -> void:
     # Make sure the art directory exists (important on a fresh checkout / export).
-    var SG_dir_err := DirAccess.make_dir_recursive(SG_ART_DIR)
+    var SG_dir_err := DirAccess.make_dir_recursive_absolute(SG_ART_DIR)
     if SG_dir_err != OK and SG_dir_err != ERR_ALREADY_EXISTS:
         push_error("ShapeGenerator: Cannot create directory %s (err %d)" % [SG_ART_DIR, SG_dir_err])
         return


### PR DESCRIPTION
## Summary
- fix directory creation in `ShapeGenerator` using absolute paths

## Testing
- `dotnet build fishtank/FishTank.sln --nologo`
- `godot --headless --check-only --quit --path fishtank --verbose` *(fails: Cannot get class 'BoidSystemConfig')*

------
https://chatgpt.com/codex/tasks/task_e_6861ea1ef3d083299b296c3a89005b13