### PR TITLE
Add tank boundary slowdown

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -12,3 +12,4 @@
 - Fixed type inference error in BoidSystem affecting build.
 - Added depth-based scaling and randomized z positions for boids.
 - Default population increased to over 50 fish across six groups.
+- Added boundary repulsion so fish slow down near walls instead of wrapping.

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - [ ] Polish boid group visuals and add unit tests for boundary logic.
 - [ ] Verify depth scaling across 6 fish groups with 50+ population.
 - [x] Resolve BoidSystem type inference error.
+- [ ] Tune boundary slowdown and bounce behavior.

--- a/scripts/entities/fish_body.gd
+++ b/scripts/entities/fish_body.gd
@@ -151,7 +151,7 @@ func _physics_process(_delta: float) -> void:
         rotation = head.rotation
 
     _update_depth_visuals()
-    _wrap_position()
+    _constrain_position()
 
 
 # ------------------------------------------------------------------
@@ -165,8 +165,8 @@ func _update_depth_visuals() -> void:
     modulate.a = a
 
 
-# Wrap instead of clamp so fish re-enter smoothly
-func _wrap_position() -> void:
-    global_position.x = wrapf(global_position.x, 0.0, tank_size.x)
-    global_position.y = wrapf(global_position.y, 0.0, tank_size.y)
+# Clamp position to keep fish inside the tank
+func _constrain_position() -> void:
+    global_position.x = clamp(global_position.x, 0.0, tank_size.x)
+    global_position.y = clamp(global_position.y, 0.0, tank_size.y)
     z_depth = clamp(z_depth, 0.0, tank_size.z)

--- a/scripts/fish/fish_agent.gd
+++ b/scripts/fish/fish_agent.gd
@@ -20,6 +20,8 @@ const FlockParameters = preload("res://scripts/boids/flock_parameters.gd")
 @export var speed_mult: float = 1.0
 @export var agility_mult: float = 1.0
 @export var preferred_depth: float = 0.0
+@export var boundary_margin: float = 50.0
+@export var boundary_force: float = 100.0
 
 var velocity: Vector2 = Vector2.ZERO
 var acceleration: Vector2 = Vector2.ZERO
@@ -65,6 +67,7 @@ func _physics_process(delta: float) -> void:
 
     # --- RANDOM WANDER ---
     _apply_wander()
+    _apply_boundary_force()
 
     # --- DRAG ---
     acceleration -= velocity * drag
@@ -164,3 +167,25 @@ func _apply_wander() -> void:
     var jitter = Vector2(_rng.randf_range(-1.0, 1.0), _rng.randf_range(-1.0, 1.0)) * wander_strength
     acceleration += jitter
     _wander_accel = jitter
+
+
+# --------------------- BOUNDARY REPULSION -----------------------
+func _apply_boundary_force() -> void:
+    if fish == null:
+        return
+    var pos: Vector2 = fish.global_position
+    var max_x: float = fish.tank_size.x
+    var max_y: float = fish.tank_size.y
+    if pos.x < boundary_margin:
+        var d = (boundary_margin - pos.x) / boundary_margin
+        acceleration.x += boundary_force * d
+    elif pos.x > max_x - boundary_margin:
+        var d = (pos.x - (max_x - boundary_margin)) / boundary_margin
+        acceleration.x -= boundary_force * d
+
+    if pos.y < boundary_margin:
+        var dy = (boundary_margin - pos.y) / boundary_margin
+        acceleration.y += boundary_force * dy
+    elif pos.y > max_y - boundary_margin:
+        var dy = (pos.y - (max_y - boundary_margin)) / boundary_margin
+        acceleration.y -= boundary_force * dy


### PR DESCRIPTION
## Summary
- add margin and force parameters for fish to bounce from edges
- apply new boundary repulsion in `FishAgent`
- clamp `FishBody` position instead of wrapping
- document TODO for tuning slowdown
- note change in changelog

## Testing
- `bash .codex/fix_indent.sh $(git diff --name-only --cached -- '*.gd') >/dev/null`
- `files=$(git diff --name-only --cached -- '*.gd'); if [ -n "$files" ]; then gdlint $files --quiet || true; fi`
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore scripts/dummy/DummyLibrary.csproj --nologo`
- `dotnet build --no-restore --nologo`
- `godot --headless -s res://tests/run_tests.gd --quiet || true`
- `dotnet test --logger "console;verbosity=quiet" || true`


------
https://chatgpt.com/codex/tasks/task_e_6861f24b954883299b9b01ee6fa4bbd6