### PR TITLE
Fix shape generator import

### DIFF
--- a/fishtank/art/shape_generator.gd
+++ b/fishtank/art/shape_generator.gd
@@ -15,7 +15,11 @@ const SG_ART_DIR := "res://art"
 
 func SG_generate_shapes_IN() -> void:
     # Make sure the art directory exists (important on a fresh checkout / export).
-    var SG_dir_err := DirAccess.make_dir_recursive(SG_ART_DIR)
+    var SG_dir := DirAccess.open("res://")
+    if SG_dir == null:
+        push_error("ShapeGenerator: Cannot access res:// directory")
+        return
+    var SG_dir_err := SG_dir.make_dir_recursive("art")
     if SG_dir_err != OK and SG_dir_err != ERR_ALREADY_EXISTS:
         push_error("ShapeGenerator: Cannot create directory %s (err %d)" % [SG_ART_DIR, SG_dir_err])
         return


### PR DESCRIPTION
## Summary
- ensure shape generator creates `art` directory by opening `DirAccess`

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet` *(fails: Cannot get class 'BoidSystemConfig')*
- `godot --headless --check-only --quit --path fishtank --quiet` *(fails: Can't create sub resource of type 'BoidSystemConfig')*
- `dotnet build fishtank/FishTank.csproj --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6861ea1ef3d083299b296c3a89005b13