### PR TITLE
Add collider and smoother wall interaction

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -22,3 +22,5 @@
 - Improved boid steering using spatial grid, separation distance, and wander.
 - Introduced `FishBehavior` enum and new behavior-related exports for `BoidFish`.
   Updated `FishArchetype` with a matching `FA_behavior_IN` field.
+- Added `Tank` collider scene and improved wall avoidance with smooth
+  deceleration and angle limits.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -15,3 +15,4 @@
 - [x] Resolve duplicate TargetFramework build attribute.
 - [ ] Improve boid flocking with wander and spatial grid.
 - [x] Add FishBehavior enum and behavior fields to fish boids.
+- [x] Reintroduce Tank collider and smooth wall steering.

--- a/fishtank/scenes/FishTank.tscn
+++ b/fishtank/scenes/FishTank.tscn
@@ -1,13 +1,22 @@
-[gd_scene load_steps=4 format=3 uid="uid://bx0kplmcvmwdp"]
+[gd_scene load_steps=6 format=3 uid="uid://bx0kplmcvmwdp"]
 
 [ext_resource type="Script" uid="uid://bsx7rq6kme2hm" path="res://scripts/fish_tank.gd" id="1"]
 [ext_resource type="Script" uid="uid://c5bs0pwcc1srx" path="res://scripts/boids/boid_system.gd" id="2"]
 
 [sub_resource type="Resource" id="1"]
 
+[sub_resource type="RectangleShape2D" id="2"]
+size = Vector2(640, 360)
+
 [node name="FishTank" type="Node2D"]
 script = ExtResource("1")
 FT_environment_IN = SubResource("1")
+
+[node name="Tank" type="Area2D" parent="."]
+position = Vector2(320, 180)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Tank"]
+shape = SubResource("2")
 
 [node name="BoidSystem" type="Node2D" parent="."]
 script = ExtResource("2")

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -26,7 +26,8 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
     if BF_velocity_UP != Vector2.ZERO:
-        rotation = BF_velocity_UP.angle()
+        var BF_target_angle_UP: float = _BF_compute_angle_IN()
+        rotation = lerp_angle(rotation, BF_target_angle_UP, 0.1)
 
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
@@ -65,3 +66,15 @@ func _BF_apply_depth_IN() -> void:
     var BF_col := modulate
     BF_col.a = lerp(0.4, 1.0, BF_ratio_UP)
     modulate = BF_col
+
+
+func _BF_compute_angle_IN() -> float:
+    var BF_dir_UP := BF_velocity_UP
+    if BF_dir_UP == Vector2.ZERO:
+        return rotation
+    var BF_left_UP: bool = BF_dir_UP.x < 0.0
+    var BF_base_angle_UP: float = atan2(BF_dir_UP.y, abs(BF_dir_UP.x))
+    BF_base_angle_UP = clamp(BF_base_angle_UP, -PI / 4.0, PI / 4.0)
+    if BF_left_UP:
+        BF_base_angle_UP = PI - BF_base_angle_UP
+    return BF_base_angle_UP

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -13,12 +13,14 @@
 class_name BoidSystem
 extends Node2D
 
+const BS_FISH_SCENE_PATH := "res://scripts/boids/boid_fish.gd"
+
 @export var BS_config_IN: BoidSystemConfig
 @export var BS_fish_scene_IN: PackedScene
 @export var BS_neighbor_radius_IN: float = 80.0
 @export var BS_separation_distance_IN: float = 40.0
 @export var BS_environment_IN: TankEnvironment
-@export var BS_group_count_IN: int = 5   # at least 5 groups
+@export var BS_group_count_IN: int = 5  # at least 5 groups
 @export var BS_group_preference_weight_IN: float = 2.0
 
 # Soft‐repulsion parameters
@@ -33,17 +35,13 @@ extends Node2D
 
 # Tint colors for each group (cyclic if >6 groups)
 var BS_group_colors := [
-    Color(1, 0, 0),   # red
-    Color(0, 1, 0),   # green
-    Color(0, 0, 1),   # blue
-    Color(1, 1, 0),   # yellow
-    Color(1, 0, 1),   # magenta
-    Color(0, 1, 1)    # cyan
+    Color(1, 0, 0), Color(0, 1, 0), Color(0, 0, 1), Color(1, 1, 0), Color(1, 0, 1), Color(0, 1, 1)  # red  # green  # blue  # yellow  # magenta  # cyan
 ]
 
 var BS_fish_nodes_SH: Array[BoidFish] = []
 var BS_rng_UP := RandomNumberGenerator.new()
 var BS_grid_SH: Dictionary = {}
+
 
 func _ready() -> void:
     if BS_config_IN == null:
@@ -57,6 +55,7 @@ func _ready() -> void:
             BS_environment_IN = TankEnvironment.new()
     BS_rng_UP.randomize()
 
+
 func _BS_ensure_fish_scene_exists_IN() -> void:
     if BS_fish_scene_IN != null and is_instance_valid(BS_fish_scene_IN):
         return  # user-provided scene is fine
@@ -67,7 +66,7 @@ func _BS_ensure_fish_scene_exists_IN() -> void:
         if BS_fish_scene_IN != null:
             return
     # Fallback: build an in-memory PackedScene so the simulation never crashes
-    var root := load("res://scripts/boids/boid_fish.gd").new() as Node2D
+    var root := load(BS_FISH_SCENE_PATH).new() as Node2D
     var sprite := Sprite2D.new()
     sprite.centered = true
     var tex_path := "res://art/ellipse_placeholder.png"
@@ -81,23 +80,24 @@ func _BS_ensure_fish_scene_exists_IN() -> void:
     else:
         push_error("BoidSystem: Failed to build fallback fish scene! (err %d)" % err)
 
+
 func BS_spawn_population_IN(archetypes: Array[FishArchetype]) -> void:
     if archetypes.is_empty():
         return
     var count: int = BS_rng_UP.randi_range(
-        BS_config_IN.BC_fish_count_min_IN,
-        BS_config_IN.BC_fish_count_max_IN
+        BS_config_IN.BC_fish_count_min_IN, BS_config_IN.BC_fish_count_max_IN
     )
     for i in range(count):
         var arch: FishArchetype = archetypes[BS_rng_UP.randi_range(0, archetypes.size() - 1)]
         _BS_spawn_fish_IN(arch)
+
 
 func _BS_spawn_fish_IN(arch: FishArchetype) -> void:
     var fish: BoidFish
     if BS_fish_scene_IN != null and is_instance_valid(BS_fish_scene_IN):
         fish = BS_fish_scene_IN.instantiate() as BoidFish
     else:
-        fish = load("res://scripts/boids/boid_fish.gd").new()
+        fish = load(BS_FISH_SCENE_PATH).new()
     # Position & depth
     if BS_environment_IN != null:
         var b: AABB = BS_environment_IN.TE_boundaries_SH
@@ -116,11 +116,14 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> void:
     add_child(fish)
     BS_fish_nodes_SH.append(fish)
 
+
 func _physics_process(delta: float) -> void:
     _BS_update_grid_IN()
     for fish in BS_fish_nodes_SH:
         _BS_update_fish_IN(fish, delta)
+        _BS_apply_wall_collider_IN(fish)
         _BS_apply_sanity_check_IN(fish, delta)
+
 
 func _BS_update_grid_IN() -> void:
     BS_grid_SH.clear()
@@ -132,6 +135,7 @@ func _BS_update_grid_IN() -> void:
         if not BS_grid_SH.has(cell):
             BS_grid_SH[cell] = []
         BS_grid_SH[cell].append(fish)
+
 
 func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     # gather neighbor sums
@@ -145,8 +149,7 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     var all_count = 0
 
     var cell = Vector2i(
-        floor(fish.position.x / BS_grid_cell_size_IN),
-        floor(fish.position.y / BS_grid_cell_size_IN)
+        floor(fish.position.x / BS_grid_cell_size_IN), floor(fish.position.y / BS_grid_cell_size_IN)
     )
     for dx in [-1, 0, 1]:
         for dy in [-1, 0, 1]:
@@ -193,7 +196,9 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     var steer = Vector2.ZERO
     if use_count > 0:
         # alignment
-        var ali_vec = (use_ali / use_count).normalized() * BS_config_IN.BC_max_speed_IN - fish.BF_velocity_UP
+        var ali_vec = (
+            (use_ali / use_count).normalized() * BS_config_IN.BC_max_speed_IN - fish.BF_velocity_UP
+        )
         ali_vec = ali_vec.limit_length(BS_config_IN.BC_max_force_IN)
         # cohesion
         var coh_vec = (use_coh / use_count) - fish.position
@@ -214,10 +219,11 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
         fish.BF_isolated_timer_UP += delta
 
     # wander
-    var wander_vec = Vector2(
-        BS_rng_UP.randf_range(-1.0, 1.0),
-        BS_rng_UP.randf_range(-1.0, 1.0)
-    ).normalized() * BS_config_IN.BC_default_wander_IN * BS_config_IN.BC_max_force_IN
+    var wander_vec = (
+        Vector2(BS_rng_UP.randf_range(-1.0, 1.0), BS_rng_UP.randf_range(-1.0, 1.0)).normalized()
+        * BS_config_IN.BC_default_wander_IN
+        * BS_config_IN.BC_max_force_IN
+    )
     steer += wander_vec
 
     # soft‐wall repulsion
@@ -283,10 +289,9 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     if BS_environment_IN != null:
         max_z = BS_environment_IN.TE_size_IN.z
     fish.BF_depth_UP = clamp(
-        fish.BF_depth_UP + BS_rng_UP.randf_range(-20.0, 20.0) * delta,
-        0.0,
-        max_z
+        fish.BF_depth_UP + BS_rng_UP.randf_range(-20.0, 20.0) * delta, 0.0, max_z
     )
+
 
 func _BS_get_weight_IN(arch: FishArchetype, field: String, default_val: float) -> float:
     if arch != null:
@@ -294,6 +299,49 @@ func _BS_get_weight_IN(arch: FishArchetype, field: String, default_val: float) -
         if typeof(val) == TYPE_FLOAT:
             return val
     return default_val
+
+
+func _BS_apply_wall_collider_IN(fish: BoidFish) -> void:
+    if BS_environment_IN == null:
+        return
+    var b = BS_environment_IN.TE_boundaries_SH
+    var min_x = b.position.x
+    var max_x = b.position.x + b.size.x
+    var min_y = b.position.y
+    var max_y = b.position.y + b.size.y
+
+    var d_left = min_x + BS_boundary_margin_IN - fish.position.x
+    if d_left > 0.0:
+        var ratio = clamp(d_left / BS_boundary_margin_IN, 0.0, 1.0)
+        fish.BF_velocity_UP.x = lerp(fish.BF_velocity_UP.x, 0.0, ratio)
+        if fish.position.x < min_x:
+            fish.position.x = min_x
+            fish.BF_velocity_UP.x = max(fish.BF_velocity_UP.x, 0.0)
+
+    var d_right = fish.position.x - (max_x - BS_boundary_margin_IN)
+    if d_right > 0.0:
+        var ratio_r = clamp(d_right / BS_boundary_margin_IN, 0.0, 1.0)
+        fish.BF_velocity_UP.x = lerp(fish.BF_velocity_UP.x, 0.0, ratio_r)
+        if fish.position.x > max_x:
+            fish.position.x = max_x
+            fish.BF_velocity_UP.x = min(fish.BF_velocity_UP.x, 0.0)
+
+    var d_top = min_y + BS_boundary_margin_IN - fish.position.y
+    if d_top > 0.0:
+        var ratio_t = clamp(d_top / BS_boundary_margin_IN, 0.0, 1.0)
+        fish.BF_velocity_UP.y = lerp(fish.BF_velocity_UP.y, 0.0, ratio_t)
+        if fish.position.y < min_y:
+            fish.position.y = min_y
+            fish.BF_velocity_UP.y = max(fish.BF_velocity_UP.y, 0.0)
+
+    var d_bottom = fish.position.y - (max_y - BS_boundary_margin_IN)
+    if d_bottom > 0.0:
+        var ratio_b = clamp(d_bottom / BS_boundary_margin_IN, 0.0, 1.0)
+        fish.BF_velocity_UP.y = lerp(fish.BF_velocity_UP.y, 0.0, ratio_b)
+        if fish.position.y > max_y:
+            fish.position.y = max_y
+            fish.BF_velocity_UP.y = min(fish.BF_velocity_UP.y, 0.0)
+
 
 func _BS_apply_sanity_check_IN(fish: BoidFish, delta: float) -> void:
     if BS_environment_IN == null:
@@ -305,14 +353,21 @@ func _BS_apply_sanity_check_IN(fish: BoidFish, delta: float) -> void:
     var min_y = b.position.y
     var max_y = b.position.y + b.size.y
     var margin = BS_boundary_margin_IN * 0.5
-    var near_edge = fish.position.x < min_x + margin or fish.position.x > max_x - margin \
-        or fish.position.y < min_y + margin or fish.position.y > max_y - margin
-    var outside = fish.position.x < min_x or fish.position.x > max_x \
-        or fish.position.y < min_y or fish.position.y > max_y
+    var near_edge = (
+        fish.position.x < min_x + margin
+        or fish.position.x > max_x - margin
+        or fish.position.y < min_y + margin
+        or fish.position.y > max_y - margin
+    )
+    var outside = (
+        fish.position.x < min_x
+        or fish.position.x > max_x
+        or fish.position.y < min_y
+        or fish.position.y > max_y
+    )
     if near_edge or outside:
         var push_dir = (Vector2(center.x, center.y) - fish.position).normalized()
         fish.BF_velocity_UP = fish.BF_velocity_UP.move_toward(
-            push_dir * BS_config_IN.BC_max_speed_IN,
-            delta * 2.0
+            push_dir * BS_config_IN.BC_max_speed_IN, delta * 2.0
         )
 # gdlint:enable = class-variable-name,function-name,function-variable-name,loop-variable-name


### PR DESCRIPTION
## Summary
- reintroduce a Tank collider in the FishTank scene
- smooth fish rotation with `_BF_compute_angle_IN`
- decelerate fish near walls with `_BS_apply_wall_collider_IN`
- document the collider change in TODO and CHANGELOG

## Testing
- `gdlint fishtank/scripts/boids/boid_system.gd fishtank/scripts/boids/boid_fish.gd >/tmp/gdlint.log || true`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68622f2145e483298325d0c8c0685fe7