### PR TITLE
Fix center spawn for dynamic BoidSystem

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -24,3 +24,5 @@
   Updated `FishArchetype` with a matching `FA_behavior_IN` field.
 - Added `TankCollider` node and collider-based confinement to keep fish
   from exiting the tank while gliding smoothly along walls.
+- Ensured `BoidSystem` uses the environment when spawned at runtime so fish
+  start at the tank center instead of the top-left corner.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -16,3 +16,4 @@
 - [ ] Improve boid flocking with wander and spatial grid.
 - [x] Add FishBehavior enum and behavior fields to fish boids.
 - [ ] Integrate TankCollider for graceful wall constraints.
+- [x] Ensure dynamic BoidSystem spawns fish at tank center.

--- a/fishtank/scripts/fish_tank.gd
+++ b/fishtank/scripts/fish_tank.gd
@@ -32,7 +32,11 @@ func _ready() -> void:
     if FT_boid_system_UP == null:
         FT_boid_system_UP = BoidSystem.new()
         FT_boid_system_UP.name = "BoidSystem"
+        FT_boid_system_UP.BS_environment_IN = FT_environment_IN
         add_child(FT_boid_system_UP)
+
+    if FT_boid_system_UP.BS_environment_IN == null:
+        FT_boid_system_UP.BS_environment_IN = FT_environment_IN
 
     if FT_boid_system_UP.BS_config_IN == null:
         FT_boid_system_UP.BS_config_IN = BoidSystemConfig.new()


### PR DESCRIPTION
## Summary
- ensure BoidSystem obtains environment before spawning fish
- document fix in CHANGELOG
- mark TODO item complete

## Testing
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6862b48366f48329a667f4192f48b13c