### PR TITLE
Fix fish spawn position

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -24,3 +24,4 @@
   Updated `FishArchetype` with a matching `FA_behavior_IN` field.
 - Added `TankCollider` node and collider-based confinement to keep fish
   from exiting the tank while gliding smoothly along walls.
+- Delayed fish spawn until BoidSystem is ready and bound to the environment.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -16,3 +16,4 @@
 - [ ] Improve boid flocking with wander and spatial grid.
 - [x] Add FishBehavior enum and behavior fields to fish boids.
 - [ ] Integrate TankCollider for graceful wall constraints.
+- [x] Ensure boid system spawns after environment setup

--- a/fishtank/scripts/fish_tank.gd
+++ b/fishtank/scripts/fish_tank.gd
@@ -37,7 +37,8 @@ func _ready() -> void:
     if FT_boid_system_UP.BS_config_IN == null:
         FT_boid_system_UP.BS_config_IN = BoidSystemConfig.new()
 
-    FT_boid_system_UP.BS_spawn_population_IN(FT_archetypes_UP)
+    FT_boid_system_UP.BS_environment_IN = FT_environment_IN
+    FT_boid_system_UP.call_deferred("BS_spawn_population_IN", FT_archetypes_UP)
 
     if FT_overlay_label_UP != null:
         FT_overlay_label_UP.text = "Loaded %d archetypes" % FT_archetypes_UP.size()


### PR DESCRIPTION
## Summary
- ensure boid system knows the environment before spawning
- spawn fish only after BoidSystem is ready
- note this fix in TODO and CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet` *(fails: Unable to open file)*
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6862b48366f48329a667f4192f48b13c