### PR TITLE
Implement fish flip-turn behavior

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -25,3 +25,5 @@
 - Added `TankCollider` node and collider-based confinement to keep fish
   from exiting the tank while gliding smoothly along walls.
 - Boids now spawn at the tank center and fade in gradually from depth.
+- Added optional flip-turn behavior with sprite deformation and direction flip
+  to smooth out sharp reversals near walls.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -17,4 +17,5 @@
 - [x] Add FishBehavior enum and behavior fields to fish boids.
 - [x] Integrate TankCollider for graceful wall constraints.
 - [ ] Tune boundary modes and group centering.
+- [x] Implement flip-turn movement mode for smoother reversals.
 - [x] Animate fish reveal and ensure spawn uses tank center.

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -353,7 +353,21 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     var max_speed: float = lerp(
         BS_config_IN.BC_depth_speed_front, BS_config_IN.BC_depth_speed_back, depth_ratio
     )
-    var desired_vel := (fish.BF_velocity_UP + BS_steer_UP).limit_length(max_speed)
+    var desired_vel: Vector2 = (fish.BF_velocity_UP + BS_steer_UP).limit_length(max_speed)
+
+    if (
+        fish.BF_archetype_IN != null
+        and fish.BF_archetype_IN.FA_movement_mode_IN == FishArchetype.MovementMode.FLIP_TURN_ENABLED
+    ):
+        var angle_diff: float = abs(fish.BF_velocity_UP.angle_to(desired_vel))
+        if (
+            angle_diff > fish.BF_archetype_IN.FA_flip_turn_threshold_IN
+            and fish.BF_flip_timer_UP <= 0.0
+        ):
+            fish._BF_start_flip_turn_IN(fish.BF_archetype_IN.FA_flip_duration_IN)
+        if fish.BF_flip_timer_UP > 0.0:
+            max_speed *= fish.BF_archetype_IN.FA_flip_speed_reduction_IN
+            desired_vel = desired_vel.limit_length(max_speed)
     fish.BF_velocity_UP = fish.BF_velocity_UP.move_toward(
         desired_vel, BS_config_IN.BC_max_force_IN * delta
     )

--- a/fishtank/scripts/data/fish_archetype.gd
+++ b/fishtank/scripts/data/fish_archetype.gd
@@ -21,6 +21,8 @@ The `FA_behavior_IN` field specifies the default `FishBehavior` for fish using
 this archetype. Values correspond to the enum defined in `BoidFish`.
 """
 
+enum MovementMode { NORMAL, FLIP_TURN_ENABLED }
+
 @export var FA_name_IN: String = ""
 @export var FA_species_list_IN: Array[String] = []
 @export var FA_placeholder_texture_IN: Texture2D
@@ -47,4 +49,8 @@ this archetype. Values correspond to the enum defined in `BoidFish`.
 @export var FA_depth_variance_IN: float = 1.0
 @export var FA_wander_speed_IN: float = 1.0
 @export var FA_special_notes_IN: String = ""
+@export var FA_movement_mode_IN: int = MovementMode.NORMAL
+@export var FA_flip_turn_threshold_IN: float = deg_to_rad(160.0)
+@export var FA_flip_duration_IN: float = 0.4
+@export var FA_flip_speed_reduction_IN: float = 0.3
 # gdlint:enable = class-variable-name


### PR DESCRIPTION
## Summary
- add flip-turn movement mode fields to `FishArchetype`
- track flip state in `BoidFish` and update visuals during turn
- detect sharp reversals in `BoidSystem` and trigger flip turns
- document feature in `CHANGELOG.md` and mark TODO done

## Testing
- `gdlint fishtank/scripts/boids/boid_fish.gd fishtank/scripts/boids/boid_system.gd fishtank/scripts/data/fish_archetype.gd`
- `godot --headless --editor --import --quit --path fishtank --verbose`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet restore fishtank/FishTank.sln --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6862f8d503408329baa9cbc46ac0ab0f