### PR TITLE
Fix push vector type mismatch

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -28,3 +28,5 @@
 - Added optional flip-turn behavior with sprite deformation and direction flip
   to smooth out sharp reversals near walls.
 - Converted boid movement math to operate in 3D while retaining 2D rendering.
+
+- Fixed 3D push-back vector in sanity check to prevent Vector2/Vector3 mix errors.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -20,3 +20,4 @@
 - [x] Implement flip-turn movement mode for smoother reversals.
 - [x] Upgrade internal boid math to Vector3 for depth-aware movement.
 - [x] Animate fish reveal and ensure spawn uses tank center.
+- [x] Fix push vector in sanity check to use Vector3

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -545,9 +545,8 @@ func _BS_apply_sanity_check_IN(fish: BoidFish, delta: float) -> void:
         or fish.BF_position_UP.y > max_y
     )
     if near_edge or outside:
-        var push_dir = (
-            (Vector2(center.x, center.y) - Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y))
-            . normalized()
+        var push_dir: Vector3 = (
+            (Vector3(center.x, center.y, fish.BF_position_UP.z) - fish.BF_position_UP).normalized()
         )
         fish.BF_velocity_UP = fish.BF_velocity_UP.move_toward(
             push_dir * BS_config_IN.BC_max_speed_IN, delta * 2.0


### PR DESCRIPTION
## Summary
- correct the push direction vector in `BoidSystem` to ensure Vector3 math
- update changelog and todo lists

## Testing
- `gdlint fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet` *(fails: Unable to open file ellipse_placeholder.png)*
- `dotnet build fishtank/FishTank.sln --no-restore --nologo` *(fails: project.assets.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631bfddc9c83298ca47d93768f3e39