### PR TITLE
Fix vector mismatch in boid sanity check

### DIFF
--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -545,11 +545,14 @@ func _BS_apply_sanity_check_IN(fish: BoidFish, delta: float) -> void:
         or fish.BF_position_UP.y > max_y
     )
     if near_edge or outside:
-        var push_dir = (
-            (Vector2(center.x, center.y) - Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y))
-            . normalized()
-        )
-        fish.BF_velocity_UP = fish.BF_velocity_UP.move_toward(
-            push_dir * BS_config_IN.BC_max_speed_IN, delta * 2.0
+        var center_3d := Vector3(center.x, center.y, fish.BF_position_UP.z)
+        var push_dir := (center_3d - fish.BF_position_UP).normalized()
+        fish.BF_velocity_UP = (
+            fish
+            . BF_velocity_UP
+            . move_toward(
+                push_dir * BS_config_IN.BC_max_speed_IN,
+                delta * 2.0,
+            )
         )
 # gdlint:enable = class-variable-name,function-name,function-variable-name,loop-variable-name


### PR DESCRIPTION
## Summary
- fix Vector2/Vector3 mismatch when nudging fish toward center
- ensure .NET solutions build

## Testing
- `gdlint fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path fishtank --verbose .`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build FISHYX3/FishyX3.sln --no-restore --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68631bfddc9c83298ca47d93768f3e39