### PR TITLE
Add fish movement tracker for debugging

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Adjusted wall boundary margin to clamp against tank size, fixing fish sticking.
 - Initial project skeleton.
 - Added empty `ui/` and `tools/` directories and updated README.
 - Introduced Mono solution with `FishTank.sln` and `FishTank.csproj`.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -16,7 +16,7 @@
 - [x] Improve boid flocking with wander and spatial grid.
 - [x] Add FishBehavior enum and behavior fields to fish boids.
 - [x] Integrate TankCollider for graceful wall constraints.
-- [ ] Tune boundary modes and group centering.
+- [x] Tune boundary modes and group centering.
 - [x] Implement flip-turn movement mode for smoother reversals.
 - [x] Upgrade internal boid math to Vector3 for depth-aware movement.
 - [x] Animate fish reveal and ensure spawn uses tank center.

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -324,10 +324,14 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
         var eff_min_y = b.position.y + BS_hard_margin_IN
         var eff_max_y = b.position.y + b.size.y - BS_hard_margin_IN
 
-        var soft_min_x = eff_min_x + BS_boundary_margin_IN
-        var soft_max_x = eff_max_x - BS_boundary_margin_IN
-        var soft_min_y = eff_min_y + BS_boundary_margin_IN
-        var soft_max_y = eff_max_y - BS_boundary_margin_IN
+        var avail_x = (eff_max_x - eff_min_x) * 0.5
+        var avail_y = (eff_max_y - eff_min_y) * 0.5
+        var margin_x = min(BS_boundary_margin_IN, avail_x)
+        var margin_y = min(BS_boundary_margin_IN, avail_y)
+        var soft_min_x = eff_min_x + margin_x
+        var soft_max_x = eff_max_x - margin_x
+        var soft_min_y = eff_min_y + margin_y
+        var soft_max_y = eff_max_y - margin_y
 
         var push = Vector3.ZERO
 
@@ -531,7 +535,9 @@ func _BS_apply_sanity_check_IN(fish: BoidFish, delta: float) -> void:
     var max_x = b.position.x + b.size.x
     var min_y = b.position.y
     var max_y = b.position.y + b.size.y
-    var margin = BS_boundary_margin_IN * 0.5
+    var avail_x2 = (max_x - min_x) * 0.5
+    var avail_y2 = (max_y - min_y) * 0.5
+    var margin = min(BS_boundary_margin_IN * 0.5, min(avail_x2, avail_y2))
     var near_edge = (
         fish.BF_position_UP.x < min_x + margin
         or fish.BF_position_UP.x > max_x - margin
@@ -545,18 +551,14 @@ func _BS_apply_sanity_check_IN(fish: BoidFish, delta: float) -> void:
         or fish.BF_position_UP.y > max_y
     )
     if near_edge or outside:
-
-        var center3 :Vector3= b.position + b.size * 0.5
-        var push3 :Vector3= (center3 - fish.BF_position_UP).normalized()
-
+        var center3: Vector3 = b.position + b.size * 0.5
+        var push3: Vector3 = (center3 - fish.BF_position_UP).normalized()
 
         fish.BF_velocity_UP = (
             fish
             . BF_velocity_UP
             . move_toward(
-
                 push3 * BS_config_IN.BC_max_speed_IN,
-
                 delta * 2.0,
             )
         )

--- a/fishtank/tools/fish_tracker.gd
+++ b/fishtank/tools/fish_tracker.gd
@@ -1,0 +1,51 @@
+# gdlint:disable = class-variable-name,function-name
+extends SceneTree
+
+var TR_log_interval_IN := 0.333
+var TR_total_time_IN := 60.0
+
+
+func _initialize() -> void:
+    call_deferred("_TR_run_IN")
+
+
+func _TR_run_IN() -> void:
+    var env := TankEnvironment.new()
+    env.TE_size_IN = Vector3(128.0, 72.0, 5.0)
+    env.TE_update_bounds_IN()
+
+    var boid_sys := BoidSystem.new()
+    boid_sys.BS_environment_IN = env
+    boid_sys.BS_group_count_IN = 1
+    get_root().add_child(boid_sys)
+
+    var loader := ArchetypeLoader.new()
+    var arches := loader.AL_load_archetypes_IN("res://data/archetypes.json")
+    if arches.is_empty():
+        arches.append(FishArchetype.new())
+    boid_sys.BS_spawn_population_IN(arches)
+
+    if boid_sys.BS_fish_nodes_SH.is_empty():
+        push_error("No fish spawned")
+        quit()
+        return
+    var fish: BoidFish = boid_sys.BS_fish_nodes_SH[0]
+    var b := env.TE_boundaries_SH
+    fish.BF_position_UP = Vector3(b.position.x + b.size.x * 0.95, b.position.y, 0.0)
+    fish.BF_velocity_UP = Vector3(40.0, 0.0, 0.0)
+
+    var steps := int(TR_total_time_IN / TR_log_interval_IN)
+    for i in range(steps):
+        boid_sys._physics_process(TR_log_interval_IN)
+        print(
+            (
+                "%0.2f, %f, %f, %f"
+                % [
+                    i * TR_log_interval_IN,
+                    fish.BF_position_UP.x,
+                    fish.BF_position_UP.y,
+                    fish.BF_position_UP.z
+                ]
+            )
+        )
+    quit()


### PR DESCRIPTION
## Summary
- add a simple headless script to log fish movement
- clamp boundary margin when applying walls so fish can slide along edges

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`
- `godot --headless --path fishtank -s res://tools/fish_tracker.gd`

------
https://chatgpt.com/codex/tasks/task_e_6863294fed248329a59a9f0420c845f3