### PR TITLE
Add simulated Z-axis deformation for fish boids

### DIFF
--- a/.codex/FISHBOID.md
+++ b/.codex/FISHBOID.md
@@ -1,0 +1,9 @@
+# Fish Boid Configuration
+
+This document lists tunable parameters exposed on `FishArchetype` that control boid visuals.
+
+## Z-Axis Turning
+- `FA_z_steer_weight_IN` – interpolation weight for simulated yaw.
+- `FA_z_deform_min_x_IN` – minimum X scale when turning sharply.
+- `FA_z_deform_max_y_IN` – maximum Y scale when turning sharply.
+- `FA_z_flip_threshold_IN` – normalized threshold for horizontal flip.

--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Converted boid movement math to operate in 3D while retaining 2D rendering.
 - Resolved Vector3 move_toward crash when fish hit tank edges.
 - Added bounce reflection in TankCollider to prevent wall sticking.
+- Added visual z-axis turning with deformation and flip support.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -21,3 +21,4 @@
 - [x] Upgrade internal boid math to Vector3 for depth-aware movement.
 - [x] Animate fish reveal and ensure spawn uses tank center.
 - [x] Fix runtime error from Vector2 argument to move_toward.
+- [x] Simulated Z-axis turning and deformation.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -38,6 +38,10 @@ var BF_wander_phase_UP: float = 0.0
 var BF_flip_timer_UP: float = 0.0
 var BF_flip_applied_SH: bool = false
 var BF_flip_duration_IN: float = 0.4
+var BF_z_angle_UP: float = 0.0
+var BF_z_steer_target_UP: float = 0.0
+var BF_z_last_angle_UP: float = 0.0
+var BF_z_flip_applied_SH: bool = false
 
 
 func _ready() -> void:
@@ -66,6 +70,24 @@ func _process(delta: float) -> void:
 
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
+
+    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var sx = 1.0
+    var sy = 1.0
+    if BF_archetype_IN != null:
+        sx = lerp(1.0, BF_archetype_IN.FA_z_deform_min_x_IN, squash_intensity)
+        sy = lerp(1.0, BF_archetype_IN.FA_z_deform_max_y_IN, squash_intensity)
+    scale = Vector2(scale.x * sx, scale.y * sy)
+    var sprite: Sprite2D = get_node_or_null("Sprite2D")
+    if BF_archetype_IN != null:
+        if squash_intensity > BF_archetype_IN.FA_z_flip_threshold_IN and not BF_z_flip_applied_SH:
+            if sign(BF_z_angle_UP) != sign(BF_z_last_angle_UP):
+                if sprite:
+                    sprite.flip_h = not sprite.flip_h
+                BF_z_flip_applied_SH = true
+        else:
+            BF_z_flip_applied_SH = false
+    BF_z_last_angle_UP = BF_z_angle_UP
 
 
 # --------------------------------------------------------------

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -359,6 +359,20 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             var to_center := (center - fish.BF_position_UP).normalized()
             BS_steer_UP += to_center * BS_wall_nudge_IN * wall_factor
 
+    fish.BF_z_steer_target_UP = Vector2(BS_steer_UP.x, BS_steer_UP.y).angle()
+    if fish.BF_archetype_IN != null:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
+        )
+    else:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            delta,
+        )
+
     var depth_ratio := 0.0
     if BS_environment_IN != null:
         depth_ratio = fish.BF_position_UP.z / BS_environment_IN.TE_size_IN.z

--- a/fishtank/scripts/data/fish_archetype.gd
+++ b/fishtank/scripts/data/fish_archetype.gd
@@ -53,4 +53,8 @@ enum MovementMode { NORMAL, FLIP_TURN_ENABLED }
 @export var FA_flip_turn_threshold_IN: float = deg_to_rad(160.0)
 @export var FA_flip_duration_IN: float = 0.4
 @export var FA_flip_speed_reduction_IN: float = 0.3
+@export var FA_z_steer_weight_IN: float = 5.0
+@export var FA_z_deform_min_x_IN: float = 0.6
+@export var FA_z_deform_max_y_IN: float = 1.4
+@export var FA_z_flip_threshold_IN: float = 0.9
 # gdlint:enable = class-variable-name


### PR DESCRIPTION
## Summary
- simulate yaw via `BF_z_angle_UP` and scale sprites
- interpolate z steering in `BoidSystem`
- expose new z-turning parameters on `FishArchetype`
- document configuration fields in `FISHBOID.md`
- note change in changelog and todo lists

## Testing
- `gdlint fishtank/scripts/boids/boid_fish.gd fishtank/scripts/boids/boid_system.gd fishtank/scripts/data/fish_archetype.gd > /tmp/gdlint.log`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --verbose > /tmp/godot_check.log` *(fails: Failed loading resource)*
- `dotnet restore fishtank/FishTank.sln --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863356978088329a1d927e4e9df6020