### PR TITLE
Add z-axis turning deformation to boid fish

### DIFF
--- a/.codex/FISHBOID.md
+++ b/.codex/FISHBOID.md
@@ -1,0 +1,29 @@
+# Fish Boid Z-Axis Deformation
+
+This document outlines the simulated yaw system for fish boids. A fake Z-angle is interpolated from steering vectors and drives visual-only deformation.
+
+## Configuration Fields
+- `FA_z_steer_weight_IN` – interpolation weight for yaw targeting
+- `FA_z_deform_min_x_IN` – minimum X scale at max bend
+- `FA_z_deform_max_y_IN` – maximum Y scale at max bend
+- `FA_z_flip_threshold_IN` – normalized intensity at which the sprite flips horizontally
+
+## Visual Processing
+`BoidFish._process()` scales the node based on `BF_z_angle_UP`:
+```
+var squash_intensity := abs(BF_z_angle_UP) / PI
+scale.x *= lerp(1.0, FA_z_deform_min_x_IN, squash_intensity)
+scale.y *= lerp(1.0, FA_z_deform_max_y_IN, squash_intensity)
+```
+If the intensity exceeds `FA_z_flip_threshold_IN` and the yaw sign reverses, `Sprite2D.flip_h` toggles to complete the turn.
+
+## Behavior Diagram
+```
+angle ↑  flip_h
+ |      /
+ |     /
+1.0 --*---- intensity
+ |    /
+ |   /
+0 --/  squash
+```

--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Converted boid movement math to operate in 3D while retaining 2D rendering.
 - Resolved Vector3 move_toward crash when fish hit tank edges.
 - Added bounce reflection in TankCollider to prevent wall sticking.
+- Introduced simulated Z-angle turning with procedural deformation and flip logic.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -21,3 +21,4 @@
 - [x] Upgrade internal boid math to Vector3 for depth-aware movement.
 - [x] Animate fish reveal and ensure spawn uses tank center.
 - [x] Fix runtime error from Vector2 argument to move_toward.
+- [x] Add visual Z-axis turning with sprite deformation and flip logic.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -38,6 +38,10 @@ var BF_wander_phase_UP: float = 0.0
 var BF_flip_timer_UP: float = 0.0
 var BF_flip_applied_SH: bool = false
 var BF_flip_duration_IN: float = 0.4
+var BF_z_angle_UP: float = 0.0
+var BF_z_steer_target_UP: float = 0.0
+var BF_z_last_angle_UP: float = 0.0
+var BF_flip_applied: bool = false
 
 
 func _ready() -> void:
@@ -66,6 +70,21 @@ func _process(delta: float) -> void:
 
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
+    if BF_archetype_IN != null:
+        var squash_intensity: float = abs(BF_z_angle_UP) / PI
+        var sx: float = lerp(1.0, BF_archetype_IN.FA_z_deform_min_x_IN, squash_intensity)
+        var sy: float = lerp(1.0, BF_archetype_IN.FA_z_deform_max_y_IN, squash_intensity)
+        scale.x *= sx
+        scale.y *= sy
+        var sprite: Sprite2D = get_node_or_null("Sprite2D")
+        if squash_intensity > BF_archetype_IN.FA_z_flip_threshold_IN and not BF_flip_applied:
+            if sign(BF_z_angle_UP) != sign(BF_z_last_angle_UP):
+                if sprite:
+                    sprite.flip_h = not sprite.flip_h
+                BF_flip_applied = true
+        else:
+            BF_flip_applied = false
+        BF_z_last_angle_UP = BF_z_angle_UP
 
 
 # --------------------------------------------------------------

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -315,6 +315,20 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     BS_steer_UP += wander_vec
 
+    fish.BF_z_steer_target_UP = Vector2(BS_steer_UP.x, BS_steer_UP.y).angle()
+    if fish.BF_archetype_IN != null:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
+        )
+    else:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            delta,
+        )
+
     # soft‐wall repulsion with slowdown and center bias
     var wall_factor = 0.0
     if BS_environment_IN != null:

--- a/fishtank/scripts/data/fish_archetype.gd
+++ b/fishtank/scripts/data/fish_archetype.gd
@@ -53,4 +53,8 @@ enum MovementMode { NORMAL, FLIP_TURN_ENABLED }
 @export var FA_flip_turn_threshold_IN: float = deg_to_rad(160.0)
 @export var FA_flip_duration_IN: float = 0.4
 @export var FA_flip_speed_reduction_IN: float = 0.3
+@export var FA_z_steer_weight_IN: float = 5.0
+@export var FA_z_deform_min_x_IN: float = 0.6
+@export var FA_z_deform_max_y_IN: float = 1.4
+@export var FA_z_flip_threshold_IN: float = 0.9
 # gdlint:enable = class-variable-name


### PR DESCRIPTION
## Summary
- support visual yaw deformation for fish with new steering angle fields
- compute yaw steering in `BoidSystem`
- squash/stretch sprite scale and flip horizontally at high angles
- document z-axis parameters

## Testing
- `godot --headless --editor --import --quit --path fishtank --verbose`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.csproj --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863356978088329a1d927e4e9df6020