### PR TITLE
Add visual yaw deformation

### DIFF
--- a/.codex/FISHBOID.md
+++ b/.codex/FISHBOID.md
@@ -1,0 +1,20 @@
+# Fish Boid Visual Yaw Deformation
+
+This document outlines the parameters controlling simulated Z-axis turning for `BoidFish`.
+
+## New Archetype Fields
+- `FA_z_steer_weight_IN` – interpolation weight used when smoothing `BF_z_angle_UP`.
+- `FA_z_deform_min_x_IN` – X-scale factor at maximum turn.
+- `FA_z_deform_max_y_IN` – Y-scale factor at maximum turn.
+- `FA_z_flip_threshold_IN` – normalized threshold for horizontal flip when reversing.
+
+## Visual Processing
+`BoidFish._process()` adjusts sprite scale based on `BF_z_angle_UP` calculated in the boid system. When the angle crosses the flip threshold and polarity changes, the sprite’s `flip_h` flag toggles to avoid popping.
+
+```gdscript
+var squash_intensity := abs(BF_z_angle_UP) / PI
+scale.x *= lerp(1.0, FA_z_deform_min_x_IN, squash_intensity)
+scale.y *= lerp(1.0, FA_z_deform_max_y_IN, squash_intensity)
+```
+
+Flips occur only when `squash_intensity` exceeds `FA_z_flip_threshold_IN`.

--- a/fishtank/fishy/proto_config - Copy.tres
+++ b/fishtank/fishy/proto_config - Copy.tres
@@ -1,3 +1,7 @@
 [gd_resource type="Resource" load_steps=0 format=3 uid="uid://dxvanq8y4y45q"]
 
 [resource]
+FA_z_steer_weight_IN = 5.0
+FA_z_deform_min_x_IN = 0.7
+FA_z_deform_max_y_IN = 1.3
+FA_z_flip_threshold_IN = 0.9

--- a/fishtank/fishy/proto_config.tres
+++ b/fishtank/fishy/proto_config.tres
@@ -1,3 +1,7 @@
 [gd_resource type="Resource" format=3 uid="uid://d3tdk2gy7yj5v"]
 
 [resource]
+FA_z_steer_weight_IN = 5.0
+FA_z_deform_min_x_IN = 0.7
+FA_z_deform_max_y_IN = 1.3
+FA_z_flip_threshold_IN = 0.9

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -38,6 +38,10 @@ var BF_wander_phase_UP: float = 0.0
 var BF_flip_timer_UP: float = 0.0
 var BF_flip_applied_SH: bool = false
 var BF_flip_duration_IN: float = 0.4
+var BF_z_angle_UP: float = 0.0
+var BF_z_steer_target_UP: float = 0.0
+var BF_z_last_angle_UP: float = 0.0
+var BF_flip_applied: bool = false
 
 
 func _ready() -> void:
@@ -66,6 +70,23 @@ func _process(delta: float) -> void:
 
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
+
+    if BF_archetype_IN != null:
+        var squash_intensity: float = abs(BF_z_angle_UP) / PI
+        var sx: float = lerp(1.0, BF_archetype_IN.FA_z_deform_min_x_IN, squash_intensity)
+        var sy: float = lerp(1.0, BF_archetype_IN.FA_z_deform_max_y_IN, squash_intensity)
+        scale.x *= sx
+        scale.y *= sy
+        if squash_intensity > BF_archetype_IN.FA_z_flip_threshold_IN and not BF_flip_applied:
+            if sign(BF_z_angle_UP) != sign(BF_z_last_angle_UP):
+                var sprite: Sprite2D = get_node_or_null("Sprite2D")
+                if sprite:
+                    sprite.flip_h = not sprite.flip_h
+                BF_flip_applied = true
+        else:
+            BF_flip_applied = false
+
+        BF_z_last_angle_UP = BF_z_angle_UP
 
 
 # --------------------------------------------------------------

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -359,6 +359,14 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             var to_center := (center - fish.BF_position_UP).normalized()
             BS_steer_UP += to_center * BS_wall_nudge_IN * wall_factor
 
+    fish.BF_z_steer_target_UP = Vector2(BS_steer_UP.x, BS_steer_UP.y).angle()
+    if fish.BF_archetype_IN != null:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
+        )
+
     var depth_ratio := 0.0
     if BS_environment_IN != null:
         depth_ratio = fish.BF_position_UP.z / BS_environment_IN.TE_size_IN.z

--- a/fishtank/scripts/data/fish_archetype.gd
+++ b/fishtank/scripts/data/fish_archetype.gd
@@ -53,4 +53,8 @@ enum MovementMode { NORMAL, FLIP_TURN_ENABLED }
 @export var FA_flip_turn_threshold_IN: float = deg_to_rad(160.0)
 @export var FA_flip_duration_IN: float = 0.4
 @export var FA_flip_speed_reduction_IN: float = 0.3
+@export var FA_z_steer_weight_IN: float = 5.0
+@export var FA_z_deform_min_x_IN: float = 0.7
+@export var FA_z_deform_max_y_IN: float = 1.3
+@export var FA_z_flip_threshold_IN: float = 0.9
 # gdlint:enable = class-variable-name


### PR DESCRIPTION
## Summary
- simulate horizontal turn angles with BF_z_angle_UP
- squash & stretch visuals in `BoidFish._process`
- flip sprites on sharp reversals
- expose new Z-axis config in `FishArchetype`
- document in `.codex/FISHBOID.md`

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`
- `dotnet build FISHYX3/FishyX3.sln --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6863356978088329a1d927e4e9df6020