### PR TITLE
Fix fish rotation to follow velocity

### DIFF
--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -359,20 +359,6 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             var to_center := (center - fish.BF_position_UP).normalized()
             BS_steer_UP += to_center * BS_wall_nudge_IN * wall_factor
 
-    fish.BF_z_steer_target_UP = Vector2(BS_steer_UP.x, BS_steer_UP.y).angle()
-    if fish.BF_archetype_IN != null:
-        fish.BF_z_angle_UP = lerp_angle(
-            fish.BF_z_angle_UP,
-            fish.BF_z_steer_target_UP,
-            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
-        )
-    else:
-        fish.BF_z_angle_UP = lerp_angle(
-            fish.BF_z_angle_UP,
-            fish.BF_z_steer_target_UP,
-            delta,
-        )
-
     var depth_ratio := 0.0
     if BS_environment_IN != null:
         depth_ratio = fish.BF_position_UP.z / BS_environment_IN.TE_size_IN.z
@@ -460,6 +446,18 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             1.0 - ratio * 0.5,
             1.0 - ratio * 0.5,
             lerp(1.0, 0.4, ratio),
+        )
+
+    var dir_vec2 := Vector2(fish.BF_velocity_UP.x, fish.BF_velocity_UP.y)
+    if dir_vec2 != Vector2.ZERO:
+        fish.BF_z_steer_target_UP = dir_vec2.angle()
+        var weight := delta
+        if fish.BF_archetype_IN != null:
+            weight = fish.BF_archetype_IN.FA_z_steer_weight_IN * delta
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            weight,
         )
 
 


### PR DESCRIPTION
## Summary
- remove outdated z-angle steering in `BoidSystem`
- compute z-axis rotation from the final velocity vector

## Testing
- `gdlint fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet` *(fails: texture import warnings)*
- `dotnet build fishtank/FishTank.sln --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68633b94876c8329bdbf5ed4ae883739