### PR TITLE
Fix fish orientation drift

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Resolved Vector3 move_toward crash when fish hit tank edges.
 - Added bounce reflection in TankCollider to prevent wall sticking.
 - Added visual z-axis turning with deformation and flip support.
+- Fixed rotation drift by basing orientation on the combined heading vector.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -22,3 +22,4 @@
 - [x] Animate fish reveal and ensure spawn uses tank center.
 - [x] Fix runtime error from Vector2 argument to move_toward.
 - [x] Simulated Z-axis turning and deformation.
+- [x] Track heading vector and align rotation to travel direction.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -28,6 +28,7 @@ const TankEnvironment = preload("res://scripts/data/tank_environment.gd")
 # --------------------------------------------------------------
 var BF_position_UP: Vector3 = Vector3.ZERO
 var BF_velocity_UP: Vector3 = Vector3.ZERO
+var BF_heading_UP: Vector3 = Vector3.RIGHT
 var BF_archetype_IN: FishArchetype
 var BF_group_id_SH: int = 0
 var BF_isolated_timer_UP: float = 0.0
@@ -58,13 +59,13 @@ func _ready() -> void:
 func _process(delta: float) -> void:
     if BF_flip_timer_UP > 0.0:
         _BF_update_flip_turn_IN(delta)
-    elif BF_velocity_UP != Vector3.ZERO:
+    elif BF_heading_UP != Vector3.ZERO:
         var turn_speed: float = 5.0
         if BF_archetype_IN != null:
             turn_speed = BF_archetype_IN.FA_turn_speed_IN
         rotation = lerp_angle(
             rotation,
-            Vector2(BF_velocity_UP.x, BF_velocity_UP.y).angle(),
+            Vector2(BF_heading_UP.x, BF_heading_UP.y).angle(),
             turn_speed * delta,
         )
 

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -165,6 +165,7 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> BoidFish:
     var ci = fish.BF_group_id_SH % BS_group_colors.size()
     fish.modulate = BS_group_colors[ci]
     fish.BF_archetype_IN = arch
+    fish.BF_heading_UP = Vector3.RIGHT
     add_child(fish)
     BS_fish_nodes_SH.append(fish)
     return fish
@@ -359,20 +360,6 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             var to_center := (center - fish.BF_position_UP).normalized()
             BS_steer_UP += to_center * BS_wall_nudge_IN * wall_factor
 
-    fish.BF_z_steer_target_UP = Vector2(BS_steer_UP.x, BS_steer_UP.y).angle()
-    if fish.BF_archetype_IN != null:
-        fish.BF_z_angle_UP = lerp_angle(
-            fish.BF_z_angle_UP,
-            fish.BF_z_steer_target_UP,
-            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
-        )
-    else:
-        fish.BF_z_angle_UP = lerp_angle(
-            fish.BF_z_angle_UP,
-            fish.BF_z_steer_target_UP,
-            delta,
-        )
-
     var depth_ratio := 0.0
     if BS_environment_IN != null:
         depth_ratio = fish.BF_position_UP.z / BS_environment_IN.TE_size_IN.z
@@ -460,6 +447,22 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             1.0 - ratio * 0.5,
             1.0 - ratio * 0.5,
             lerp(1.0, 0.4, ratio),
+        )
+
+    if fish.BF_velocity_UP.length_squared() > 0.001:
+        fish.BF_heading_UP = fish.BF_velocity_UP.normalized()
+    fish.BF_z_steer_target_UP = Vector2(fish.BF_heading_UP.x, fish.BF_heading_UP.y).angle()
+    if fish.BF_archetype_IN != null:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
+        )
+    else:
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            delta,
         )
 
 


### PR DESCRIPTION
## Summary
- update boid fish to store heading vector
- rotate based on heading instead of raw velocity
- compute heading after applying forces in `BoidSystem`
- document change in TODO and CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet` *(fails: unable to load some resources)*
- `dotnet build fishtank/FishTank.sln --no-restore --nologo` *(fails: missing `project.assets.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68633b94876c8329bdbf5ed4ae883739