### PR TITLE
Fix fish orientation drift

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -31,3 +31,5 @@
 - Resolved Vector3 move_toward crash when fish hit tank edges.
 - Added bounce reflection in TankCollider to prevent wall sticking.
 - Added visual z-axis turning with deformation and flip support.
+
+- Corrected fish rotation to follow travel direction.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -22,3 +22,5 @@
 - [x] Animate fish reveal and ensure spawn uses tank center.
 - [x] Fix runtime error from Vector2 argument to move_toward.
 - [x] Simulated Z-axis turning and deformation.
+
+- [ ] Fix fish orientation drift

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -359,20 +359,6 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
             var to_center := (center - fish.BF_position_UP).normalized()
             BS_steer_UP += to_center * BS_wall_nudge_IN * wall_factor
 
-    fish.BF_z_steer_target_UP = Vector2(BS_steer_UP.x, BS_steer_UP.y).angle()
-    if fish.BF_archetype_IN != null:
-        fish.BF_z_angle_UP = lerp_angle(
-            fish.BF_z_angle_UP,
-            fish.BF_z_steer_target_UP,
-            fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
-        )
-    else:
-        fish.BF_z_angle_UP = lerp_angle(
-            fish.BF_z_angle_UP,
-            fish.BF_z_steer_target_UP,
-            delta,
-        )
-
     var depth_ratio := 0.0
     if BS_environment_IN != null:
         depth_ratio = fish.BF_position_UP.z / BS_environment_IN.TE_size_IN.z
@@ -410,6 +396,20 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    if fish.BF_velocity_UP != Vector3.ZERO:
+        fish.BF_z_steer_target_UP = Vector2(fish.BF_velocity_UP.x, fish.BF_velocity_UP.y).angle()
+        if fish.BF_archetype_IN != null:
+            fish.BF_z_angle_UP = lerp_angle(
+                fish.BF_z_angle_UP,
+                fish.BF_z_steer_target_UP,
+                fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
+            )
+        else:
+            fish.BF_z_angle_UP = lerp_angle(
+                fish.BF_z_angle_UP,
+                fish.BF_z_steer_target_UP,
+                delta,
+            )
 
     # hard‐wall deceleration
     if BS_environment_IN != null:


### PR DESCRIPTION
## Summary
- rotate fish toward current velocity after forces are applied
- track open task for orientation drift
- update change log

## Testing
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68633b94876c8329bdbf5ed4ae883739