### PR TITLE
Fix fishtank turning squash drift

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -33,3 +33,4 @@
 - Added visual z-axis turning with deformation and flip support.
 
 - Corrected fish rotation to follow travel direction.
+- Fixed z-axis squash sticking after turns by tracking current orientation.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -22,5 +22,4 @@
 - [x] Animate fish reveal and ensure spawn uses tank center.
 - [x] Fix runtime error from Vector2 argument to move_toward.
 - [x] Simulated Z-axis turning and deformation.
-
-- [ ] Fix fish orientation drift
+- [x] Fix fish orientation drift

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -39,7 +39,6 @@ var BF_flip_timer_UP: float = 0.0
 var BF_flip_applied_SH: bool = false
 var BF_flip_duration_IN: float = 0.4
 var BF_z_angle_UP: float = 0.0
-var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 
@@ -67,6 +66,7 @@ func _process(delta: float) -> void:
             Vector2(BF_velocity_UP.x, BF_velocity_UP.y).angle(),
             turn_speed * delta,
         )
+    BF_z_angle_UP = rotation
 
     if BF_environment_IN != null:
         _BF_apply_depth_IN()

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -396,20 +396,6 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
-    if fish.BF_velocity_UP != Vector3.ZERO:
-        fish.BF_z_steer_target_UP = Vector2(fish.BF_velocity_UP.x, fish.BF_velocity_UP.y).angle()
-        if fish.BF_archetype_IN != null:
-            fish.BF_z_angle_UP = lerp_angle(
-                fish.BF_z_angle_UP,
-                fish.BF_z_steer_target_UP,
-                fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
-            )
-        else:
-            fish.BF_z_angle_UP = lerp_angle(
-                fish.BF_z_angle_UP,
-                fish.BF_z_steer_target_UP,
-                delta,
-            )
 
     # hard‐wall deceleration
     if BS_environment_IN != null:


### PR DESCRIPTION
## Summary
- track BF_z_angle_UP from current rotation
- remove unused z angle update logic
- mark orientation TODO as done
- document fix in CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686343439a3883298ff8087a8762706e