### PR TITLE
Fix z-axis squash orientation sync

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -33,3 +33,4 @@
 - Added visual z-axis turning with deformation and flip support.
 
 - Corrected fish rotation to follow travel direction.
+- Fixed z-axis squash to realign after turns.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -23,4 +23,4 @@
 - [x] Fix runtime error from Vector2 argument to move_toward.
 - [x] Simulated Z-axis turning and deformation.
 
-- [ ] Fix fish orientation drift
+- [x] Fix fish orientation drift

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -40,7 +40,8 @@ var BF_flip_applied_SH: bool = false
 var BF_flip_duration_IN: float = 0.4
 var BF_z_angle_UP: float = 0.0
 var BF_z_steer_target_UP: float = 0.0
-var BF_z_last_angle_UP: float = 0.0
+var BF_z_turn_diff_UP: float = 0.0
+var BF_z_last_turn_diff_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 
 
@@ -71,7 +72,8 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    BF_z_turn_diff_UP = wrapf(BF_z_angle_UP - rotation, -PI, PI)
+    var squash_intensity = abs(BF_z_turn_diff_UP) / PI
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:
@@ -81,13 +83,13 @@ func _process(delta: float) -> void:
     var sprite: Sprite2D = get_node_or_null("Sprite2D")
     if BF_archetype_IN != null:
         if squash_intensity > BF_archetype_IN.FA_z_flip_threshold_IN and not BF_z_flip_applied_SH:
-            if sign(BF_z_angle_UP) != sign(BF_z_last_angle_UP):
+            if sign(BF_z_turn_diff_UP) != sign(BF_z_last_turn_diff_UP):
                 if sprite:
                     sprite.flip_h = not sprite.flip_h
                 BF_z_flip_applied_SH = true
         else:
             BF_z_flip_applied_SH = false
-    BF_z_last_angle_UP = BF_z_angle_UP
+    BF_z_last_turn_diff_UP = BF_z_turn_diff_UP
 
 
 # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- track current z turn difference
- use diff between velocity angle and rotation for squash
- log fix in TODO and CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686343439a3883298ff8087a8762706e