### PR TITLE
Fix dynamic squash with 3D direction

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Squash intensity now reflects vertical movement.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [ ] Apply squash based on vertical velocity

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -397,26 +397,29 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
     if fish.BF_velocity_UP != Vector3.ZERO:
-        fish.BF_z_steer_target_UP = (
+        fish.BF_rot_target_UP = (
             Vector2(
                 fish.BF_velocity_UP.x,
                 fish.BF_velocity_UP.y,
             )
             . angle()
         )
-        fish.BF_rot_target_UP = fish.BF_z_steer_target_UP
+        var xy_len := (
+            Vector2(
+                fish.BF_velocity_UP.x,
+                fish.BF_velocity_UP.y,
+            )
+            . length()
+        )
+        fish.BF_z_steer_target_UP = atan2(fish.BF_velocity_UP.z, xy_len)
+        var steer_weight := delta
         if fish.BF_archetype_IN != null:
-            fish.BF_z_angle_UP = lerp_angle(
-                fish.BF_z_angle_UP,
-                fish.BF_z_steer_target_UP,
-                fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
-            )
-        else:
-            fish.BF_z_angle_UP = lerp_angle(
-                fish.BF_z_angle_UP,
-                fish.BF_z_steer_target_UP,
-                delta,
-            )
+            steer_weight = fish.BF_archetype_IN.FA_z_steer_weight_IN * delta
+        fish.BF_z_angle_UP = lerp_angle(
+            fish.BF_z_angle_UP,
+            fish.BF_z_steer_target_UP,
+            steer_weight,
+        )
 
     # hard‐wall deceleration
     if BS_environment_IN != null:


### PR DESCRIPTION
## Summary
- update squash logic to follow velocity's Z angle
- note vertical movement squash in CHANGELOG
- add TODO item for squash based on vertical velocity

## Testing
- `gdlint fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore fishtank/FishTank.sln --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686347da55188329854b17d86d02762d