### PR TITLE
Apply z-axis squash outside wall turns

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Z-axis squash now responds to regular movement, not just wall turns.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [ ] Apply z-axis squash during regular movement

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -68,7 +68,7 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = abs(BF_z_angle_UP) / (PI * 0.5)
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -397,14 +397,22 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
     if fish.BF_velocity_UP != Vector3.ZERO:
-        fish.BF_z_steer_target_UP = (
+        var bs_yaw_UP := (
             Vector2(
                 fish.BF_velocity_UP.x,
                 fish.BF_velocity_UP.y,
             )
             . angle()
         )
-        fish.BF_rot_target_UP = fish.BF_z_steer_target_UP
+        var bs_hspeed_UP := (
+            Vector2(
+                fish.BF_velocity_UP.x,
+                fish.BF_velocity_UP.y,
+            )
+            . length()
+        )
+        fish.BF_rot_target_UP = bs_yaw_UP
+        fish.BF_z_steer_target_UP = atan2(fish.BF_velocity_UP.z, bs_hspeed_UP)
         if fish.BF_archetype_IN != null:
             fish.BF_z_angle_UP = lerp_angle(
                 fish.BF_z_angle_UP,


### PR DESCRIPTION
## Summary
- recalc z-steer angle using depth movement
- scale deformation based on this angle
- note new tuning in TODO and CHANGELOG

## Testing
- `dotnet format fishtank/FishTank.sln --verify-no-changes --no-restore --severity info`
- `dotnet format FISHYX3/FishyX3.sln --verify-no-changes --no-restore --severity info`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686347da55188329854b17d86d02762d