### PR TITLE
Implement vertical-turn squash effect

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Squash deformation now mirrors vertical turns, not just wall collisions.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Apply orientation squash during vertical turns

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -68,7 +68,8 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = abs(BF_z_angle_UP) / (PI * 0.5)
+    squash_intensity = clamp(squash_intensity, 0.0, 1.0)
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -397,14 +397,9 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
     if fish.BF_velocity_UP != Vector3.ZERO:
-        fish.BF_z_steer_target_UP = (
-            Vector2(
-                fish.BF_velocity_UP.x,
-                fish.BF_velocity_UP.y,
-            )
-            . angle()
-        )
-        fish.BF_rot_target_UP = fish.BF_z_steer_target_UP
+        var horiz := Vector2(fish.BF_velocity_UP.x, fish.BF_velocity_UP.y)
+        fish.BF_rot_target_UP = horiz.angle()
+        fish.BF_z_steer_target_UP = atan2(fish.BF_velocity_UP.z, horiz.length())
         if fish.BF_archetype_IN != null:
             fish.BF_z_angle_UP = lerp_angle(
                 fish.BF_z_angle_UP,


### PR DESCRIPTION
## Summary
- update boid orientation calculations to track vertical movement
- scale fish sprites based on pitch angle intensity
- document behavior update in CHANGELOG and TODO

## Testing
- `gdlint fishtank/scripts/boids/boid_fish.gd fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet restore fishtank/FishTank.sln --no-cache --ignore-failed-sources --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_686347da55188329854b17d86d02762d