### PR TITLE
Improve fish squash effects

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Squash effect based on turn angle now applies even away from walls.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Squash now responds to turning anywhere, not just near walls

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -397,14 +397,19 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
     if fish.BF_velocity_UP != Vector3.ZERO:
-        fish.BF_z_steer_target_UP = (
+        var vel_angle := (
             Vector2(
                 fish.BF_velocity_UP.x,
                 fish.BF_velocity_UP.y,
             )
             . angle()
         )
-        fish.BF_rot_target_UP = fish.BF_z_steer_target_UP
+        fish.BF_rot_target_UP = vel_angle
+        fish.BF_z_steer_target_UP = wrapf(
+            vel_angle - fish.rotation,
+            -PI,
+            PI,
+        )
         if fish.BF_archetype_IN != null:
             fish.BF_z_angle_UP = lerp_angle(
                 fish.BF_z_angle_UP,


### PR DESCRIPTION
## Summary
- allow z-turn squash to respond to movement direction changes
- document updated squash behavior

## Testing
- `bash .codex/fix_indent.sh fishtank/scripts/boids/boid_system.gd`
- `gdlint fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path fishtank`
- `godot --headless --check-only --quit --path fishtank` *(fails: RID allocations and resource leaks)*
- `dotnet build fishtank/FishTank.sln`

------
https://chatgpt.com/codex/tasks/task_e_686347da55188329854b17d86d02762d