### PR TITLE
Track fish orientation via head & tail points

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Tracked head and tail positions for 3D orientation-based deformation.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Track head and tail positions to compute 3D orientation

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -22,6 +22,7 @@ const TankEnvironment = preload("res://scripts/data/tank_environment.gd")
 # Exports
 # --------------------------------------------------------------
 @export var BF_depth_lerp_speed_IN: float = 1.0
+@export var BF_body_length_IN: float = 20.0
 
 # --------------------------------------------------------------
 # Vars
@@ -43,6 +44,8 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_head_pos_UP: Vector3 = Vector3.ZERO
+var BF_tail_pos_UP: Vector3 = Vector3.ZERO
 
 
 func _ready() -> void:
@@ -52,6 +55,10 @@ func _ready() -> void:
     rng.randomize()
     BF_wander_phase_UP = rng.randf_range(0.0, TAU)
     BF_target_depth_SH = BF_position_UP.z
+    BF_head_pos_UP = BF_position_UP
+    BF_tail_pos_UP = (
+        BF_position_UP - (Vector3(cos(rotation), sin(rotation), 0.0) * BF_body_length_IN)
+    )
     if BF_archetype_IN != null:
         BF_behavior_SH = BF_archetype_IN.FA_behavior_IN
 
@@ -85,6 +92,10 @@ func _process(delta: float) -> void:
         else:
             BF_z_flip_applied_SH = false
     BF_z_last_angle_UP = BF_z_angle_UP
+    BF_head_pos_UP = BF_position_UP
+    BF_tail_pos_UP = (
+        BF_position_UP - (Vector3(cos(BF_z_angle_UP), sin(BF_z_angle_UP), 0.0) * BF_body_length_IN)
+    )
 
 
 # --------------------------------------------------------------

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -165,6 +165,8 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> BoidFish:
     var ci = fish.BF_group_id_SH % BS_group_colors.size()
     fish.modulate = BS_group_colors[ci]
     fish.BF_archetype_IN = arch
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    fish.BF_tail_pos_UP = fish.BF_position_UP - Vector3(1, 0, 0) * fish.BF_body_length_IN
     add_child(fish)
     BS_fish_nodes_SH.append(fish)
     return fish
@@ -417,6 +419,12 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
                 fish.BF_z_steer_target_UP,
                 delta,
             )
+
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    fish.BF_tail_pos_UP = (
+        fish.BF_position_UP
+        - (Vector3(cos(fish.BF_z_angle_UP), sin(fish.BF_z_angle_UP), 0.0) * fish.BF_body_length_IN)
+    )
 
     # hard‐wall deceleration
     if BS_environment_IN != null:


### PR DESCRIPTION
## Summary
- add `BF_body_length_IN` and head/tail vectors in `BoidFish`
- initialize and update head/tail points in boid logic
- mention new feature in TODO and CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`
- `dotnet build FISHYX3/FishyX3.sln --no-restore --nologo` *(fails: missing project.assets.json)*

------
https://chatgpt.com/codex/tasks/task_e_68634d86ae7c8329a8e06c7f024bbca4