### PR TITLE
Add head/tail orientation tracking

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Added head and tail tracking to derive 3D squash intensity.

--- a/fishtank/README.md
+++ b/fishtank/README.md
@@ -2,6 +2,7 @@
 
 This directory houses a modular aquarium simulation scaffold built with Godot 4.4.
 It is organized for extensibility and data-driven development.
+Each fish records head and tail points in 3D space so sprite deformation can mimic depth when turning.
 
 ## Directory Layout
 - `data/` – JSON and resource files describing archetypes and tank settings

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- Track head and tail 3D positions to compute squash intensity.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -43,6 +43,8 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_head_point_UP: Vector3 = Vector3.ZERO
+var BF_tail_point_UP: Vector3 = Vector3.ZERO
 
 
 func _ready() -> void:
@@ -68,7 +70,8 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var orientation_vec: Vector3 = BF_head_point_UP - BF_tail_point_UP
+    var squash_intensity = abs(orientation_vec.z) / max(orientation_vec.length(), 0.001)
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -417,6 +417,13 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
                 fish.BF_z_steer_target_UP,
                 delta,
             )
+        var forward_vec := Vector3(
+            cos(fish.BF_rot_target_UP) * cos(fish.BF_z_angle_UP),
+            sin(fish.BF_rot_target_UP) * cos(fish.BF_z_angle_UP),
+            sin(fish.BF_z_angle_UP),
+        )
+        fish.BF_head_point_UP = fish.BF_position_UP + forward_vec * 0.5
+        fish.BF_tail_point_UP = fish.BF_position_UP - forward_vec * 0.5
 
     # hard‐wall deceleration
     if BS_environment_IN != null:


### PR DESCRIPTION
## Summary
- compute 3D squash intensity using head and tail points
- update BoidSystem to maintain those points
- document new orientation logic in README
- note the update in TODO and CHANGELOG

## Testing
- `gdlint $(git diff --name-only HEAD~1 -- '*.gd') || true`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --editor --import --quit --path FISHYX3 --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path FISHYX3 --quiet`
- `dotnet restore fishtank/FishTank.sln --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`
- `dotnet restore FISHYX3/FishyX3.sln --nologo`
- `dotnet build FISHYX3/FishyX3.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68634d86ae7c8329a8e06c7f024bbca4