### PR TITLE
Add head/tail tracking for fish orientation

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Added head/tail tracking for accurate 3D orientation and squash.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Track head and tail positions for 3D orientation

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -43,6 +43,9 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_z_pitch_UP: float = 0.0
+var BF_head_point_UP: Vector3 = Vector3.ZERO
+var BF_tail_point_UP: Vector3 = Vector3.ZERO
 
 
 func _ready() -> void:
@@ -52,6 +55,8 @@ func _ready() -> void:
     rng.randomize()
     BF_wander_phase_UP = rng.randf_range(0.0, TAU)
     BF_target_depth_SH = BF_position_UP.z
+    BF_head_point_UP = BF_position_UP
+    BF_tail_point_UP = BF_position_UP - Vector3.RIGHT
     if BF_archetype_IN != null:
         BF_behavior_SH = BF_archetype_IN.FA_behavior_IN
 
@@ -68,7 +73,7 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = clamp(abs(BF_z_pitch_UP) / (PI * 0.5), 0.0, 1.0)
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -165,6 +165,8 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> BoidFish:
     var ci = fish.BF_group_id_SH % BS_group_colors.size()
     fish.modulate = BS_group_colors[ci]
     fish.BF_archetype_IN = arch
+    fish.BF_head_point_UP = fish.BF_position_UP
+    fish.BF_tail_point_UP = fish.BF_position_UP - Vector3.RIGHT
     add_child(fish)
     BS_fish_nodes_SH.append(fish)
     return fish
@@ -417,6 +419,20 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
                 fish.BF_z_steer_target_UP,
                 delta,
             )
+
+        fish.BF_tail_point_UP = fish.BF_head_point_UP
+        fish.BF_head_point_UP = fish.BF_position_UP
+        var orient_vec := fish.BF_head_point_UP - fish.BF_tail_point_UP
+        if orient_vec.length() > 0.0:
+            var pitch := asin(clamp(orient_vec.z / orient_vec.length(), -1.0, 1.0))
+            if fish.BF_archetype_IN != null:
+                fish.BF_z_pitch_UP = lerp(
+                    fish.BF_z_pitch_UP,
+                    pitch,
+                    fish.BF_archetype_IN.FA_z_steer_weight_IN * delta,
+                )
+            else:
+                fish.BF_z_pitch_UP = lerp(fish.BF_z_pitch_UP, pitch, delta)
 
     # hard‐wall deceleration
     if BS_environment_IN != null:


### PR DESCRIPTION
## Summary
- track head and tail points on each fish
- compute pitch from head/tail orientation for better squash
- record head/tail orientation in `BoidSystem`
- update changelog and todo

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68634d86ae7c8329a8e06c7f024bbca4