### PR TITLE
Add pitch-based squash for vertical fish motion

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Fish now track vertical pitch and squash stretches during dives.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -43,6 +43,9 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_pitch_UP: float = 0.0
+var BF_head_pos_UP: Vector3 = Vector3.ZERO
+var BF_tail_pos_UP: Vector3 = Vector3.ZERO
 
 
 func _ready() -> void:
@@ -52,6 +55,8 @@ func _ready() -> void:
     rng.randomize()
     BF_wander_phase_UP = rng.randf_range(0.0, TAU)
     BF_target_depth_SH = BF_position_UP.z
+    BF_head_pos_UP = BF_position_UP
+    BF_tail_pos_UP = BF_position_UP
     if BF_archetype_IN != null:
         BF_behavior_SH = BF_archetype_IN.FA_behavior_IN
 
@@ -68,7 +73,7 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = abs(BF_pitch_UP) / PI
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -161,6 +161,8 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> BoidFish:
         )
         fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
     # assign group and tint
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    fish.BF_tail_pos_UP = fish.BF_position_UP
     fish.BF_group_id_SH = BS_rng_UP.randi_range(0, BS_group_count_IN - 1)
     var ci = fish.BF_group_id_SH % BS_group_colors.size()
     fish.modulate = BS_group_colors[ci]
@@ -396,6 +398,32 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    var tail_target := fish.BF_position_UP - fish.BF_velocity_UP.normalized() * 10.0
+    fish.BF_tail_pos_UP = (
+        fish
+        . BF_tail_pos_UP
+        . move_toward(
+            tail_target,
+            50.0 * delta,
+        )
+    )
+    var horiz_len := (
+        Vector2(
+            fish.BF_head_pos_UP.x - fish.BF_tail_pos_UP.x,
+            fish.BF_head_pos_UP.y - fish.BF_tail_pos_UP.y,
+        )
+        . length()
+    )
+    var pitch_target := atan2(
+        fish.BF_head_pos_UP.z - fish.BF_tail_pos_UP.z,
+        horiz_len,
+    )
+    fish.BF_pitch_UP = lerp_angle(
+        fish.BF_pitch_UP,
+        pitch_target,
+        5.0 * delta,
+    )
     if fish.BF_velocity_UP != Vector3.ZERO:
         fish.BF_z_steer_target_UP = (
             Vector2(


### PR DESCRIPTION
## Summary
- track head and tail positions to compute fish pitch
- update BoidSystem to maintain pitch
- squash sprites based on pitch instead of yaw
- document pitch-driven squash in CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene defined)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863a92f55f88329ab4a9a941c03b15f