### PR TITLE
Implement pitch-based boid deformation

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Introduced pitch-based deformation when fish dive or ascend.

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -43,6 +43,9 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_pitch_UP: float = 0.0
+var BF_head_pos_UP: Vector3 = Vector3.ZERO
+var BF_tail_pos_UP: Vector3 = Vector3.ZERO
 
 
 func _ready() -> void:
@@ -68,7 +71,7 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = abs(BF_pitch_UP) / PI
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -386,6 +386,9 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
         if fish.BF_flip_timer_UP > 0.0:
             max_speed *= fish.BF_archetype_IN.FA_flip_speed_reduction_IN
             desired_vel = desired_vel.limit_length(max_speed)
+    var prev_head := fish.BF_head_pos_UP
+    if prev_head == Vector3.ZERO:
+        prev_head = fish.BF_position_UP
     fish.BF_velocity_UP = (
         fish
         . BF_velocity_UP
@@ -396,6 +399,19 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    fish.BF_tail_pos_UP = fish.BF_tail_pos_UP.move_toward(prev_head, 5.0 * delta)
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    var pitch_target := atan2(
+        fish.BF_head_pos_UP.z - fish.BF_tail_pos_UP.z,
+        (
+            Vector2(
+                fish.BF_head_pos_UP.x - fish.BF_tail_pos_UP.x,
+                fish.BF_head_pos_UP.y - fish.BF_tail_pos_UP.y,
+            )
+            . length()
+        ),
+    )
+    fish.BF_pitch_UP = lerp_angle(fish.BF_pitch_UP, pitch_target, 5.0 * delta)
     if fish.BF_velocity_UP != Vector3.ZERO:
         fish.BF_z_steer_target_UP = (
             Vector2(


### PR DESCRIPTION
## Summary
- track fish pitch and head/tail positions
- compute pitch in `BoidSystem` and use it for sprite squash
- document new behaviour in the changelog

## Testing
- `gdlint fishtank/scripts/boids/boid_fish.gd fishtank/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863a92f55f88329ab4a9a941c03b15f