### PR TITLE
Implement pitch-based deformation for boids

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Added pitch tracking so vertical motion deforms sprites with realistic squash.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Apply pitch-based sprite squash during depth changes

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -42,6 +42,9 @@ var BF_z_angle_UP: float = 0.0
 var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
+var BF_pitch_UP: float = 0.0
+var BF_head_pos_UP: Vector3 = Vector3.ZERO
+var BF_tail_pos_UP: Vector3 = Vector3.ZERO
 var BF_rot_target_UP: float = 0.0
 
 
@@ -68,7 +71,7 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = abs(BF_pitch_UP) / PI
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -160,6 +160,8 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> BoidFish:
             0.0,
         )
         fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    fish.BF_tail_pos_UP = fish.BF_position_UP
     # assign group and tint
     fish.BF_group_id_SH = BS_rng_UP.randi_range(0, BS_group_count_IN - 1)
     var ci = fish.BF_group_id_SH % BS_group_colors.size()
@@ -396,6 +398,21 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    fish.BF_tail_pos_UP = (
+        fish
+        . BF_tail_pos_UP
+        . move_toward(
+            fish.BF_head_pos_UP,
+            delta * 5.0,
+        )
+    )
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    var pitch_diff := fish.BF_head_pos_UP - fish.BF_tail_pos_UP
+    var pitch_target := atan2(
+        pitch_diff.z,
+        Vector2(pitch_diff.x, pitch_diff.y).length(),
+    )
+    fish.BF_pitch_UP = lerp_angle(fish.BF_pitch_UP, pitch_target, delta * 5.0)
     if fish.BF_velocity_UP != Vector3.ZERO:
         fish.BF_z_steer_target_UP = (
             Vector2(


### PR DESCRIPTION
## Summary
- track head/tail positions and pitch on each boid
- use pitch instead of yaw for squash deformation
- update BoidSystem to compute pitch as fish dive or ascend
- log vertical squash in `CHANGELOG`
- mark TODO for pitch deformation complete

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --verbose`
- `dotnet build fishtank/FishTank.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863a92f55f88329ab4a9a941c03b15f