### PR TITLE
Add pitch-based squash tracking

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Sprites now squash when diving or rising based on tracked pitch.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Deform sprites using pitch derived from head and tail positions

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -43,6 +43,9 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_pitch_UP: float = 0.0
+var BF_head_pos_UP: Vector3 = Vector3.ZERO
+var BF_tail_pos_UP: Vector3 = Vector3.ZERO
 
 
 func _ready() -> void:
@@ -52,6 +55,8 @@ func _ready() -> void:
     rng.randomize()
     BF_wander_phase_UP = rng.randf_range(0.0, TAU)
     BF_target_depth_SH = BF_position_UP.z
+    BF_head_pos_UP = BF_position_UP
+    BF_tail_pos_UP = BF_position_UP
     if BF_archetype_IN != null:
         BF_behavior_SH = BF_archetype_IN.FA_behavior_IN
 
@@ -68,7 +73,7 @@ func _process(delta: float) -> void:
     if BF_environment_IN != null:
         _BF_apply_depth_IN()
 
-    var squash_intensity = abs(BF_z_angle_UP) / PI
+    var squash_intensity = abs(BF_pitch_UP) / PI
     var sx = 1.0
     var sy = 1.0
     if BF_archetype_IN != null:

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -396,6 +396,20 @@ func _BS_update_fish_IN(fish: BoidFish, delta: float) -> void:
     )
     fish.BF_position_UP += fish.BF_velocity_UP * delta
     fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    fish.BF_head_pos_UP = fish.BF_position_UP
+    var tail_target := fish.BF_head_pos_UP - fish.BF_velocity_UP
+    fish.BF_tail_pos_UP = fish.BF_tail_pos_UP.move_toward(tail_target, delta * 5.0)
+    var pitch_target := atan2(
+        fish.BF_head_pos_UP.z - fish.BF_tail_pos_UP.z,
+        (
+            Vector2(
+                fish.BF_head_pos_UP.x - fish.BF_tail_pos_UP.x,
+                fish.BF_head_pos_UP.y - fish.BF_tail_pos_UP.y,
+            )
+            . length()
+        ),
+    )
+    fish.BF_pitch_UP = lerp_angle(fish.BF_pitch_UP, pitch_target, delta * 5.0)
     if fish.BF_velocity_UP != Vector3.ZERO:
         fish.BF_z_steer_target_UP = (
             Vector2(


### PR DESCRIPTION
## Summary
- track pitch and new head/tail points on `BoidFish`
- update `BoidSystem` to compute pitch from a lagging tail
- squash sprites using pitch instead of yaw
- note new behaviour in changelog and complete TODO

## Testing
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene defined)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore fishtank/FishTank.sln --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863a92f55f88329ab4a9a941c03b15f