### PR TITLE
Continuous banking deformation

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Bank deformation now recalculates per-frame to avoid drift.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Recompute bank scale every frame for smooth unsquash

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -43,11 +43,13 @@ var BF_z_steer_target_UP: float = 0.0
 var BF_z_last_angle_UP: float = 0.0
 var BF_z_flip_applied_SH: bool = false
 var BF_rot_target_UP: float = 0.0
+var BF_default_scale_SH: Vector2 = Vector2.ONE
 
 
 func _ready() -> void:
     set_process(true)
     _BF_ensure_visual_IN()
+    BF_default_scale_SH = scale
     var rng := RandomNumberGenerator.new()
     rng.randomize()
     BF_wander_phase_UP = rng.randf_range(0.0, TAU)
@@ -65,26 +67,7 @@ func _process(delta: float) -> void:
             turn_speed = BF_archetype_IN.FA_turn_speed_IN
         rotation = lerp_angle(rotation, BF_rot_target_UP, turn_speed * delta)
 
-    if BF_environment_IN != null:
-        _BF_apply_depth_IN()
-
-    var squash_intensity = abs(BF_z_angle_UP) / PI
-    var sx = 1.0
-    var sy = 1.0
-    if BF_archetype_IN != null:
-        sx = lerp(1.0, BF_archetype_IN.FA_z_deform_min_x_IN, squash_intensity)
-        sy = lerp(1.0, BF_archetype_IN.FA_z_deform_max_y_IN, squash_intensity)
-    scale = Vector2(scale.x * sx, scale.y * sy)
-    var sprite: Sprite2D = get_node_or_null("Sprite2D")
-    if BF_archetype_IN != null:
-        if squash_intensity > BF_archetype_IN.FA_z_flip_threshold_IN and not BF_z_flip_applied_SH:
-            if sign(BF_z_angle_UP) != sign(BF_z_last_angle_UP):
-                if sprite:
-                    sprite.flip_h = not sprite.flip_h
-                BF_z_flip_applied_SH = true
-        else:
-            BF_z_flip_applied_SH = false
-    BF_z_last_angle_UP = BF_z_angle_UP
+    _BF_apply_visuals_IN()
 
 
 # --------------------------------------------------------------
@@ -105,23 +88,6 @@ func _BF_ensure_visual_IN() -> void:
     add_child(sprite)
 
 
-func _BF_apply_depth_IN() -> void:
-    var BF_ratio_UP: float = clamp(
-        (BF_environment_IN.TE_size_IN.z - BF_position_UP.z) / BF_environment_IN.TE_size_IN.z,
-        0.0,
-        1.0,
-    )
-
-    # Scale
-    var BF_scale_UP: float = lerp(0.5, 1.0, BF_ratio_UP)
-    scale = Vector2.ONE * BF_scale_UP
-
-    # Tint / opacity
-    var BF_col := modulate
-    BF_col.a = lerp(0.4, 1.0, BF_ratio_UP)
-    modulate = BF_col
-
-
 func _BF_start_flip_turn_IN(duration: float) -> void:
     BF_flip_duration_IN = duration
     BF_flip_timer_UP = duration
@@ -131,23 +97,47 @@ func _BF_start_flip_turn_IN(duration: float) -> void:
 func _BF_update_flip_turn_IN(delta: float) -> void:
     BF_flip_timer_UP = max(BF_flip_timer_UP - delta, 0.0)
     var half := BF_flip_duration_IN * 0.5
+    if BF_flip_timer_UP <= half and not BF_flip_applied_SH:
+        BF_flip_applied_SH = true
+        var sprite: Sprite2D = get_node_or_null("Sprite2D")
+        if sprite:
+            sprite.flip_h = not sprite.flip_h
+        BF_velocity_UP = -BF_velocity_UP
+
+
+func _BF_apply_visuals_IN() -> void:
+    var depth_ratio := 1.0
+    if BF_environment_IN != null:
+        depth_ratio = clamp(
+            (BF_environment_IN.TE_size_IN.z - BF_position_UP.z) / BF_environment_IN.TE_size_IN.z,
+            0.0,
+            1.0,
+        )
+
+    var depth_scale = lerp(0.5, 1.0, depth_ratio)
+    var bank_intensity = clamp(abs(BF_z_angle_UP) / PI, 0.0, 1.0)
+    var sx = 1.0
+    var sy = 1.0
+    if BF_archetype_IN != null:
+        sx = lerp(1.0, BF_archetype_IN.FA_z_deform_min_x_IN, bank_intensity)
+        sy = lerp(1.0, BF_archetype_IN.FA_z_deform_max_y_IN, bank_intensity)
+
+    var final_scale: Vector2 = BF_default_scale_SH * depth_scale
+    final_scale.x *= sx
+    final_scale.y *= sy
+    scale = final_scale
+
+    var col := modulate
+    col.a = lerp(0.4, 1.0, depth_ratio)
+    modulate = col
+
     var sprite: Sprite2D = get_node_or_null("Sprite2D")
-    var sx := 1.0
-    var sy := 1.0
-    if BF_flip_timer_UP > half:
-        var t := 1.0 - (BF_flip_timer_UP - half) / half
-        sx = lerp(1.0, 0.6, t)
-        sy = lerp(1.0, 1.4, t)
-    else:
-        if not BF_flip_applied_SH:
-            BF_flip_applied_SH = true
-            if sprite:
-                sprite.flip_h = not sprite.flip_h
-            BF_velocity_UP = -BF_velocity_UP
-        var t2 := 1.0 - BF_flip_timer_UP / half
-        sx = lerp(0.6, 1.0, t2)
-        sy = lerp(1.4, 1.0, t2)
-    if sprite:
-        sprite.scale = Vector2(sx, sy)
-    if BF_flip_timer_UP == 0.0 and sprite:
-        sprite.scale = Vector2.ONE
+    if BF_archetype_IN != null:
+        if bank_intensity > BF_archetype_IN.FA_z_flip_threshold_IN and not BF_z_flip_applied_SH:
+            if sign(BF_z_angle_UP) != sign(BF_z_last_angle_UP):
+                if sprite:
+                    sprite.flip_h = not sprite.flip_h
+                BF_z_flip_applied_SH = true
+        else:
+            BF_z_flip_applied_SH = false
+    BF_z_last_angle_UP = BF_z_angle_UP


### PR DESCRIPTION
## Summary
- recalculated bank scaling from baseline scale every frame
- removed sprite scaling from flip-turn logic
- tracked default sprite scale for reference
- updated changelog and todo

## Testing
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet restore fishtank/FishTank.sln --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6863bab1c0c48329b029cff923cb0821