### PR TITLE
Add archetype resource loading

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -2,4 +2,5 @@
 
 ## [Unreleased]
 - Tank size now updates from the viewport each frame.
+- Added built-in archetypes loading and override property in GameManager.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -1,4 +1,5 @@
 # TODO
 - Document remaining features from PLAN.md.
 - Review performance at larger fish counts.
+- Create built-in archetypes folder and load defaults automatically.
 

--- a/BOIDFIsh/fishyfishyfishy/archetypes/algae_patrol/bristlenose_pleco.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/algae_patrol/bristlenose_pleco.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "BristlenosePleco"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(180, 50, 180)
+FA_max_speed_IN = 90.0
+FA_wander_weight_IN = 1.3
+FA_flock_type_IN = "BOTTOM_DWELLER"
+FA_depth_pref_IN = 1.0
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.85
+FA_deform_max_y_IN = 1.15
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 10

--- a/BOIDFIsh/fishyfishyfishy/archetypes/algae_patrol/siamese_algae_eater.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/algae_patrol/siamese_algae_eater.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "SiameseAlgaeEater"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(160, 45, 160)
+FA_max_speed_IN = 100.0
+FA_wander_weight_IN = 1.3
+FA_flock_type_IN = "BOTTOM_DWELLER"
+FA_depth_pref_IN = 0.8
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.85
+FA_deform_max_y_IN = 1.15
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 11

--- a/BOIDFIsh/fishyfishyfishy/archetypes/bottom_parade/habrosus_cory.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/bottom_parade/habrosus_cory.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "HabrosusCory"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(90, 28, 90)
+FA_max_speed_IN = 105.0
+FA_wander_weight_IN = 1.2
+FA_flock_type_IN = "BOTTOM_DWELLER"
+FA_depth_pref_IN = 0.9
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 9

--- a/BOIDFIsh/fishyfishyfishy/archetypes/bottom_parade/sterbai_cory.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/bottom_parade/sterbai_cory.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "SterbaiCory"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(100, 30, 100)
+FA_max_speed_IN = 110.0
+FA_wander_weight_IN = 1.2
+FA_flock_type_IN = "BOTTOM_DWELLER"
+FA_depth_pref_IN = 0.9
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 8

--- a/BOIDFIsh/fishyfishyfishy/archetypes/graceful_gliders/marble_angelfish.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/graceful_gliders/marble_angelfish.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "MarbleAngelfish"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(220, 70, 220)
+FA_max_speed_IN = 130.0
+FA_wander_weight_IN = 0.6
+FA_flock_type_IN = "CRUISER"
+FA_depth_pref_IN = 0.3
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.8
+FA_deform_max_y_IN = 1.2
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 4

--- a/BOIDFIsh/fishyfishyfishy/archetypes/graceful_gliders/veil_angelfish.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/graceful_gliders/veil_angelfish.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "VeilAngelfish"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(230, 75, 230)
+FA_max_speed_IN = 125.0
+FA_wander_weight_IN = 0.6
+FA_flock_type_IN = "CRUISER"
+FA_depth_pref_IN = 0.3
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.8
+FA_deform_max_y_IN = 1.2
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 5

--- a/BOIDFIsh/fishyfishyfishy/archetypes/lazy_cruisers/dwarf_gourami.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/lazy_cruisers/dwarf_gourami.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "DwarfGourami"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(140, 45, 140)
+FA_max_speed_IN = 95.0
+FA_wander_weight_IN = 0.9
+FA_flock_type_IN = "LONER"
+FA_depth_pref_IN = 0.6
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 7

--- a/BOIDFIsh/fishyfishyfishy/archetypes/lazy_cruisers/pearl_gourami.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/lazy_cruisers/pearl_gourami.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "PearlGourami"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(150, 50, 150)
+FA_max_speed_IN = 100.0
+FA_wander_weight_IN = 0.9
+FA_flock_type_IN = "LONER"
+FA_depth_pref_IN = 0.6
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 6

--- a/BOIDFIsh/fishyfishyfishy/archetypes/mid_accents/boesemani.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/mid_accents/boesemani.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "BoesemaniRainbow"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(200, 60, 200)
+FA_max_speed_IN = 160.0
+FA_wander_weight_IN = 0.8
+FA_flock_type_IN = "SHOAL"
+FA_depth_pref_IN = 0.4
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.85
+FA_deform_max_y_IN = 1.15
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 2

--- a/BOIDFIsh/fishyfishyfishy/archetypes/mid_accents/turquoise.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/mid_accents/turquoise.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "TurquoiseRainbow"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(190, 60, 190)
+FA_max_speed_IN = 150.0
+FA_wander_weight_IN = 0.8
+FA_flock_type_IN = "SHOAL"
+FA_depth_pref_IN = 0.5
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.85
+FA_deform_max_y_IN = 1.15
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 3

--- a/BOIDFIsh/fishyfishyfishy/archetypes/tiny_schoolers/cardinal.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/tiny_schoolers/cardinal.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "CardinalTetra"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(80, 20, 80)
+FA_max_speed_IN = 120.0
+FA_wander_weight_IN = 1.0
+FA_flock_type_IN = "SCHOOL"
+FA_depth_pref_IN = 0.4
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 0

--- a/BOIDFIsh/fishyfishyfishy/archetypes/tiny_schoolers/neon.tres
+++ b/BOIDFIsh/fishyfishyfishy/archetypes/tiny_schoolers/neon.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+resource_name = "NeonTetra"
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(70, 18, 70)
+FA_max_speed_IN = 110.0
+FA_wander_weight_IN = 1.0
+FA_flock_type_IN = "SCHOOL"
+FA_depth_pref_IN = 0.5
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 1

--- a/BOIDFIsh/fishyfishyfishy/scripts/boids/boid_system.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/boids/boid_system.gd
@@ -109,13 +109,38 @@ func get_neighbors(fish: BoidFish, radius: float) -> Array[BoidFish]:
 func _ensure_archetypes() -> void:
     ## Guarantees at least one archetype exists to avoid runtime errors.
     if FB_archetypes_IN.is_empty():
-        push_warning(
-            "BoidSystem: No FishArchetype resources assigned – generating default archetype."
-        )
-        var default_arch: FishArchetype = FishArchetype.new()  # Uses class defaults.
-        FB_archetypes_IN.append(default_arch)
+        _load_archetypes_from_dir("res://archetypes")
+        if FB_archetypes_IN.is_empty():
+            push_warning(
+                "BoidSystem: No FishArchetype resources assigned – generating default archetype."
+            )
+            var default_arch: FishArchetype = FishArchetype.new()  # Uses class defaults.
+            FB_archetypes_IN.append(default_arch)
+        else:
+            pass
     else:
         pass
+
+
+func _load_archetypes_from_dir(path: String) -> void:
+    var dir := DirAccess.open(path)
+    if dir == null:
+        return
+    dir.list_dir_begin()
+    var file := dir.get_next()
+    while file != "":
+        if file.begins_with("."):
+            pass
+        elif dir.current_is_dir():
+            _load_archetypes_from_dir(path + "/" + file)
+        elif file.get_extension() == "tres":
+            var res := load(path + "/" + file)
+            if res is FishArchetype:
+                FB_archetypes_IN.append(res)
+            else:
+                pass
+        file = dir.get_next()
+    dir.list_dir_end()
 
 
 func _add_fish(amount: int) -> void:

--- a/BOIDFIsh/fishyfishyfishy/scripts/core/game_manager.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/core/game_manager.gd
@@ -1,5 +1,6 @@
-extends Node
+# gdlint:disable = class-variable-name,function-name,class-definitions-order
 class_name GameManager
+extends Node
 ## Singleton that exposes user settings & debug flags.
 
 # --------------------------------------------------------------------- #
@@ -8,6 +9,7 @@ class_name GameManager
 @export_range(50, 600, 1) var GM_fish_count_IN: int = 300
 @export_range(0.5, 1.5, 0.01) var GM_depth_scale_IN: float = 1.0
 @export_enum("Community", "Reef", "Night") var GM_theme_IN: String = "Community"
+@export var GM_archetypes_override_IN: Array[FishArchetype] = []
 
 # --------------------------------------------------------------------- #
 #  Inspector – Debug Flags                                              #
@@ -33,6 +35,7 @@ signal depth_scale_changed(new_scale: float)
 signal theme_changed(new_theme: String)
 signal debug_toggled(enabled: bool)
 
+
 # --------------------------------------------------------------------- #
 #  Lifecycle                                                            #
 # --------------------------------------------------------------------- #
@@ -43,6 +46,8 @@ func _ready() -> void:
     if GM_boid_system_RD == null:
         push_error("GameManager could not find FishBoidSim child node.")
     else:
+        if not GM_archetypes_override_IN.is_empty():
+            GM_boid_system_RD.FB_archetypes_IN = GM_archetypes_override_IN.duplicate()
         GM_boid_system_RD.set_fish_count(GM_fish_count_IN)
 
     if GM_renderer_RD == null:


### PR DESCRIPTION
## Summary
- add `archetypes` folder with 12 preset .tres resources
- allow BoidSystem to auto-load archetypes from the new folder
- expose `GM_archetypes_override_IN` in GameManager for overriding default sets
- load overrides on startup
- update TODO and CHANGE_LOG

## Testing
- `gdformat --use-spaces=4 BOIDFIsh/fishyfishyfishy/scripts/core/game_manager.gd BOIDFIsh/fishyfishyfishy/scripts/boids/boid_system.gd`
- `gdlint BOIDFIsh/fishyfishyfishy/scripts/core/game_manager.gd BOIDFIsh/fishyfishyfishy/scripts/boids/boid_system.gd`
- `godot --headless --editor --import --quit --path BOIDFIsh/fishyfishyfishy --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/fishyfishyfishy --quiet`
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6864458b15b8832985022d60187320fd