### PR TITLE
Add fish archetype data and loader

### DIFF
--- a/BOIDFIsh/fishyfishyfishy/data/archetypes.json
+++ b/BOIDFIsh/fishyfishyfishy/data/archetypes.json
@@ -1,0 +1,10 @@
+{
+  "archetypes": [
+    "res://data/schooler.tres",
+    "res://data/cruiser.tres",
+    "res://data/glider.tres",
+    "res://data/loner.tres",
+    "res://data/bottom_dweller.tres",
+    "res://data/custodian.tres"
+  ]
+}

--- a/BOIDFIsh/fishyfishyfishy/data/bottom_dweller.tres
+++ b/BOIDFIsh/fishyfishyfishy/data/bottom_dweller.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" format=3]
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(90, 35, 100)
+FA_max_speed_IN = 130
+FA_wander_weight_IN = 0.4
+FA_flock_type_IN = "BOTTOM_DWELLER"
+FA_depth_pref_IN = 0.95
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 4

--- a/BOIDFIsh/fishyfishyfishy/data/cruiser.tres
+++ b/BOIDFIsh/fishyfishyfishy/data/cruiser.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" format=3]
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(120, 40, 140)
+FA_max_speed_IN = 160
+FA_wander_weight_IN = 0.4
+FA_flock_type_IN = "CRUISER"
+FA_depth_pref_IN = 0.25
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 1

--- a/BOIDFIsh/fishyfishyfishy/data/custodian.tres
+++ b/BOIDFIsh/fishyfishyfishy/data/custodian.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" format=3]
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(70, 20, 80)
+FA_max_speed_IN = 120
+FA_wander_weight_IN = 0.3
+FA_flock_type_IN = "BOTTOM_DWELLER"
+FA_depth_pref_IN = 0.9
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.9
+FA_deform_max_y_IN = 1.05
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 5

--- a/BOIDFIsh/fishyfishyfishy/data/glider.tres
+++ b/BOIDFIsh/fishyfishyfishy/data/glider.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" format=3]
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(150, 60, 160)
+FA_max_speed_IN = 140
+FA_wander_weight_IN = 0.5
+FA_flock_type_IN = "SHOAL"
+FA_depth_pref_IN = 0.6
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.8
+FA_deform_max_y_IN = 1.2
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 2

--- a/BOIDFIsh/fishyfishyfishy/data/loner.tres
+++ b/BOIDFIsh/fishyfishyfishy/data/loner.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" format=3]
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(100, 50, 120)
+FA_max_speed_IN = 150
+FA_wander_weight_IN = 0.7
+FA_flock_type_IN = "LONER"
+FA_depth_pref_IN = 0.45
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.85
+FA_deform_max_y_IN = 1.15
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 3

--- a/BOIDFIsh/fishyfishyfishy/data/schooler.tres
+++ b/BOIDFIsh/fishyfishyfishy/data/schooler.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" format=3]
+[ext_resource type="Script" path="res://scripts/data/fish_archetype.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+FA_size_vec3_IN = Vector3(80, 30, 90)
+FA_max_speed_IN = 180
+FA_wander_weight_IN = 0.6
+FA_flock_type_IN = "SCHOOL"
+FA_depth_pref_IN = 0.5
+FA_z_steer_weight_IN = 1.0
+FA_deform_min_x_IN = 0.85
+FA_deform_max_y_IN = 1.1
+FA_flip_thresh_IN = 0.0
+FA_palette_id_IN = 0

--- a/BOIDFIsh/fishyfishyfishy/scripts/core/game_manager.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/core/game_manager.gd
@@ -24,6 +24,7 @@ class_name GameManager
 # --------------------------------------------------------------------- #
 var GM_boid_system_RD: BoidSystem
 var GM_renderer_RD: FishRenderer
+@export var GM_archetype_file_IN: String = "res://data/archetypes.json"
 
 # --------------------------------------------------------------------- #
 #  Signals                                                              #
@@ -32,6 +33,7 @@ signal fish_count_changed(new_count: int)
 signal depth_scale_changed(new_scale: float)
 signal theme_changed(new_theme: String)
 signal debug_toggled(enabled: bool)
+
 
 # --------------------------------------------------------------------- #
 #  Lifecycle                                                            #
@@ -49,6 +51,8 @@ func _ready() -> void:
         push_error("GameManager could not find FishRenderer child node.")
     else:
         GM_renderer_RD.set_depth_scale(GM_depth_scale_IN)
+
+    _GM_load_archetypes()
 
 
 # --------------------------------------------------------------------- #
@@ -93,3 +97,23 @@ func set_depth_scale(scale: float) -> void:
 func set_theme(theme: String) -> void:
     GM_theme_IN = theme
     theme_changed.emit(theme)
+
+
+func _GM_load_archetypes() -> void:
+    if GM_boid_system_RD == null:
+        return
+
+    var archetypes: Array[FishArchetype] = []
+    if FileAccess.file_exists(GM_archetype_file_IN):
+        var f = FileAccess.open(GM_archetype_file_IN, FileAccess.READ)
+        var json = JSON.new()
+        if json.parse(f.get_as_text()) == OK:
+            var data = json.data
+            if typeof(data) == TYPE_DICTIONARY and data.has("archetypes"):
+                for path in data["archetypes"]:
+                    var res = load(path)
+                    if res:
+                        archetypes.append(res)
+
+    if not archetypes.is_empty():
+        GM_boid_system_RD.FB_archetypes_IN = archetypes

--- a/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
@@ -9,25 +9,33 @@
 extends Node2D
 class_name FishRenderer
 
-@export var FR_sprite_texture_IN : Texture2D
-@export var FR_front_scale_SH    : float = 1.0
-@export var FR_back_scale_SH     : float = 0.4
+@export var FR_sprite_texture_IN: Texture2D
+@export var FR_front_scale_SH: float = 1.0
+@export var FR_back_scale_SH: float = 0.4
 
-const FR_NEAR_BRIGHT_SH : float = 1.00
-const FR_FAR_BRIGHT_SH  : float = 0.55
+const FR_NEAR_BRIGHT_SH: float = 1.00
+const FR_FAR_BRIGHT_SH: float = 0.55
 
 @export_group("Debug Visuals")
-@export_range(1.0, 20.0, 0.5, "suffix:px")
-var FR_dbg_point_radius_IN : float = 4.0
-@export_range(1.0, 10.0, 0.5, "suffix:px")
-var FR_dbg_line_width_IN   : float = 2.0
-@export var FR_dbg_color_IN : Color = Color.YELLOW
+@export_range(1.0, 20.0, 0.5, "suffix:px") var FR_dbg_point_radius_IN: float = 4.0
+@export_range(1.0, 10.0, 0.5, "suffix:px") var FR_dbg_line_width_IN: float = 2.0
+@export var FR_dbg_color_IN: Color = Color.YELLOW
 @export_group("")
 
-var FR_boid_system_RD        : BoidSystem
-var FR_multimesh_SH          : MultiMesh             = MultiMesh.new()
-var FR_multimesh_instance_SH : MultiMeshInstance2D
-var _gm : GameManager
+var FR_boid_system_RD: BoidSystem
+var FR_multimesh_SH: MultiMesh = MultiMesh.new()
+var FR_multimesh_instance_SH: MultiMeshInstance2D
+var _gm: GameManager
+var FR_rng_SH: RandomNumberGenerator = RandomNumberGenerator.new()
+const FR_PALETTES_SH: Array[Color] = [
+    Color("#ff5555"),
+    Color("#55ff99"),
+    Color("#5599ff"),
+    Color("#ffcc55"),
+    Color("#99ffaa"),
+    Color("#cc55ff")
+]
+
 
 # ------------------------------------------------------------------ #
 func _ready() -> void:
@@ -37,46 +45,53 @@ func _ready() -> void:
         return
 
     _gm = get_tree().root.get_node_or_null("GameManager")
+    FR_rng_SH.randomize()
 
     FR_multimesh_SH.transform_format = MultiMesh.TRANSFORM_2D
-    FR_multimesh_SH.use_colors       = true
-    var quad := QuadMesh.new(); quad.size = Vector2.ONE
+    FR_multimesh_SH.use_colors = true
+    var quad := QuadMesh.new()
+    quad.size = Vector2.ONE
     FR_multimesh_SH.mesh = quad
     FR_multimesh_SH.instance_count = 0
 
     FR_multimesh_instance_SH = MultiMeshInstance2D.new()
     FR_multimesh_instance_SH.multimesh = FR_multimesh_SH
-    if FR_sprite_texture_IN: FR_multimesh_instance_SH.texture = FR_sprite_texture_IN
-    else: push_warning("FishRenderer: FR_sprite_texture_IN is null – fish will show as solid quads.")
+    if FR_sprite_texture_IN:
+        FR_multimesh_instance_SH.texture = FR_sprite_texture_IN
+    else:
+        push_warning("FishRenderer: FR_sprite_texture_IN is null – fish will show as solid quads.")
     add_child(FR_multimesh_instance_SH)
 
     set_process(true)
 
+
 func set_depth_scale(scale: float) -> void:
     FR_front_scale_SH = scale
-    FR_back_scale_SH  = clamp(scale * 0.4, 0.05, scale)
+    FR_back_scale_SH = clamp(scale * 0.4, 0.05, scale)
+
 
 # ------------------------------------------------------------------ #
 func _process(_delta: float) -> void:
-    if FR_boid_system_RD == null: return
+    if FR_boid_system_RD == null:
+        return
 
-    var snapshot : Array = FR_boid_system_RD.get_snapshot()
+    var snapshot: Array = FR_boid_system_RD.get_snapshot()
     _resize_multimesh(snapshot.size())
 
-    var tank_depth : float = FR_boid_system_RD.FB_tank_size_IN.z
-    var i : int = 0
+    var tank_depth: float = FR_boid_system_RD.FB_tank_size_IN.z
+    var i: int = 0
 
     for item in snapshot:
-        var head : Vector3 = item["head"]
-        var tail : Vector3 = item["tail"]
+        var head: Vector3 = item["head"]
+        var tail: Vector3 = item["tail"]
 
-        var depth_ratio : float = head.z / max(tank_depth, 0.001)
-        var scale        : float = lerp(FR_front_scale_SH, FR_back_scale_SH, depth_ratio)
-        var brightness   : float = lerp(FR_NEAR_BRIGHT_SH,  FR_FAR_BRIGHT_SH, depth_ratio)
+        var depth_ratio: float = head.z / max(tank_depth, 0.001)
+        var scale: float = lerp(FR_front_scale_SH, FR_back_scale_SH, depth_ratio)
+        var brightness: float = lerp(FR_NEAR_BRIGHT_SH, FR_FAR_BRIGHT_SH, depth_ratio)
 
-        var head2 : Vector2 = Vector2(head.x, head.y)
-        var tail2 : Vector2 = Vector2(tail.x, tail.y)
-        var angle : float   = (head2 - tail2).angle()
+        var head2: Vector2 = Vector2(head.x, head.y)
+        var tail2: Vector2 = Vector2(tail.x, tail.y)
+        var angle: float = (head2 - tail2).angle()
 
         var xf := Transform2D.IDENTITY
         xf = xf.scaled(Vector2(scale, scale))
@@ -84,11 +99,29 @@ func _process(_delta: float) -> void:
         xf = xf.translated(head2)
 
         FR_multimesh_SH.set_instance_transform_2d(i, xf)
-        FR_multimesh_SH.set_instance_color(i, Color(brightness, brightness, brightness, 1.0))
+
+        var species_id: int = int(item["species_id"])
+        var palette_idx: int = 0
+        if species_id < FR_boid_system_RD.FB_archetypes_IN.size():
+            palette_idx = FR_boid_system_RD.FB_archetypes_IN[species_id].FA_palette_id_IN
+
+        var base_col: Color = FR_PALETTES_SH[palette_idx % FR_PALETTES_SH.size()]
+        FR_rng_SH.seed = species_id * 4096 + i
+        var shift: float = FR_rng_SH.randf_range(-0.1, 0.1)
+        var tint: Color
+        if shift >= 0.0:
+            tint = base_col.lightened(shift)
+        else:
+            tint = base_col.darkened(-shift)
+        var final_col: Color = Color(
+            tint.r * brightness, tint.g * brightness, tint.b * brightness, 1.0
+        )
+        FR_multimesh_SH.set_instance_color(i, final_col)
         i += 1
 
     if _gm and _gm.GM_debug_enabled_SH and _gm.GM_draw_spines_SH:
         queue_redraw()
+
 
 # ------------------------------------------------------------------ #
 func _draw() -> void:
@@ -98,16 +131,17 @@ func _draw() -> void:
     # *** FIXED LINE (identity transform for drawing) ***
     draw_set_transform(Vector2.ZERO, 0.0, Vector2.ONE)
 
-    var snapshot : Array = FR_boid_system_RD.get_snapshot()
+    var snapshot: Array = FR_boid_system_RD.get_snapshot()
     for item in snapshot:
-        var head : Vector3 = item["head"]
-        var tail : Vector3 = item["tail"]
-        var head2 : Vector2 = Vector2(head.x, head.y)
-        var tail2 : Vector2 = Vector2(tail.x, tail.y)
+        var head: Vector3 = item["head"]
+        var tail: Vector3 = item["tail"]
+        var head2: Vector2 = Vector2(head.x, head.y)
+        var tail2: Vector2 = Vector2(tail.x, tail.y)
 
         draw_line(tail2, head2, FR_dbg_color_IN, FR_dbg_line_width_IN, true)
         draw_circle(head2, FR_dbg_point_radius_IN, FR_dbg_color_IN)
         draw_circle(tail2, FR_dbg_point_radius_IN, FR_dbg_color_IN)
+
 
 # ------------------------------------------------------------------ #
 func _resize_multimesh(required: int) -> void:


### PR DESCRIPTION
## Summary
- provide JSON index and six FishArchetype resources
- load archetypes from JSON on GameManager startup
- tint fish variants by palette ID in FishRenderer

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/fishyfishyfishy --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/fishyfishyfishy --quiet`
- `dotnet build --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686452a686088329ad8cbd90abedca89