### PR TITLE
Expose depth scaling constants in inspector

### DIFF
--- a/FISHYX3/scripts/entities/fish_body.gd
+++ b/FISHYX3/scripts/entities/fish_body.gd
@@ -4,6 +4,7 @@
 #  • Added wrap-around edges (no corner-lock)
 #  • Added HARD SPEED CAP so no fish can exceed max_safe_speed
 ###############################################################
+# gdlint:disable = class-variable-name,function-name
 
 class_name FishBody
 extends Node2D
@@ -11,10 +12,10 @@ extends Node2D
 # ------------------------------------------------------------------
 #  CONSTANTS
 # ------------------------------------------------------------------
-const MIN_SCALE := 0.6
-const MAX_SCALE := 1.0
-const MIN_ALPHA := 0.5
-const MAX_ALPHA := 1.0
+@export var min_depth_scale: float = 0.6
+@export var max_depth_scale: float = 1.0
+@export var min_depth_alpha: float = 0.5
+@export var max_depth_alpha: float = 1.0
 
 # ------------------------------------------------------------------
 #  EXPORTED TUNABLES
@@ -159,9 +160,9 @@ func _physics_process(_delta: float) -> void:
 # ------------------------------------------------------------------
 func _update_depth_visuals() -> void:
     var t: float = clamp((tank_size.z - z_depth) / tank_size.z, 0.0, 1.0)
-    var sc: float = lerp(MIN_SCALE, MAX_SCALE, t)
+    var sc: float = lerp(min_depth_scale, max_depth_scale, t)
     scale = Vector2(sc, sc)
-    var a: float = lerp(MIN_ALPHA, MAX_ALPHA, t)
+    var a: float = lerp(min_depth_alpha, max_depth_alpha, t)
     modulate.a = a
 
 

--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -34,3 +34,4 @@
 
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
+- Added inspector options for depth scale and opacity ranges in BoidSystem.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -25,3 +25,4 @@
 
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
+- [x] Expose depth scale and opacity ranges on BoidSystem

--- a/fishtank/scripts/boids/boid_fish.gd
+++ b/fishtank/scripts/boids/boid_fish.gd
@@ -32,6 +32,7 @@ var BF_archetype_IN: FishArchetype
 var BF_group_id_SH: int = 0
 var BF_isolated_timer_UP: float = 0.0
 var BF_environment_IN: TankEnvironment
+var BF_boid_system_IN: BoidSystem
 var BF_behavior_SH: int = FishBehavior.SCHOOL
 var BF_target_depth_SH: float = 0.0
 var BF_wander_phase_UP: float = 0.0
@@ -112,13 +113,21 @@ func _BF_apply_depth_IN() -> void:
         1.0,
     )
 
-    # Scale
-    var BF_scale_UP: float = lerp(0.5, 1.0, BF_ratio_UP)
+    var BF_scale_min := 0.5
+    var BF_scale_max := 1.0
+    var BF_alpha_min := 0.4
+    var BF_alpha_max := 1.0
+    if BF_boid_system_IN != null:
+        BF_scale_min = BF_boid_system_IN.BS_depth_scale_far_IN
+        BF_scale_max = BF_boid_system_IN.BS_depth_scale_near_IN
+        BF_alpha_min = BF_boid_system_IN.BS_depth_alpha_far_IN
+        BF_alpha_max = BF_boid_system_IN.BS_depth_alpha_near_IN
+
+    var BF_scale_UP: float = lerp(BF_scale_min, BF_scale_max, BF_ratio_UP)
     scale = Vector2.ONE * BF_scale_UP
 
-    # Tint / opacity
     var BF_col := modulate
-    BF_col.a = lerp(0.4, 1.0, BF_ratio_UP)
+    BF_col.a = lerp(BF_alpha_min, BF_alpha_max, BF_ratio_UP)
     modulate = BF_col
 
 

--- a/fishtank/scripts/boids/boid_system.gd
+++ b/fishtank/scripts/boids/boid_system.gd
@@ -38,6 +38,12 @@ extends Node2D
 @export var BS_collider_IN: TankCollider
 @export var BS_reveal_batch_IN: int = 3
 @export var BS_reveal_interval_IN: float = 0.2
+
+# Depth scaling parameters used by BoidFish
+@export var BS_depth_scale_far_IN: float = 0.5
+@export var BS_depth_scale_near_IN: float = 1.0
+@export var BS_depth_alpha_far_IN: float = 0.4
+@export var BS_depth_alpha_near_IN: float = 1.0
 var BS_fish_nodes_SH: Array[BoidFish] = []
 # gdlint:ignore-start
 
@@ -160,6 +166,7 @@ func _BS_spawn_fish_IN(arch: FishArchetype) -> BoidFish:
             0.0,
         )
         fish.position = Vector2(fish.BF_position_UP.x, fish.BF_position_UP.y)
+    fish.BF_boid_system_IN = self
     # assign group and tint
     fish.BF_group_id_SH = BS_rng_UP.randi_range(0, BS_group_count_IN - 1)
     var ci = fish.BF_group_id_SH % BS_group_colors.size()


### PR DESCRIPTION
## Summary
- expose depth scale/alpha ranges on `BoidSystem`
- allow `BoidFish` to read parameters from its system
- add depth range exports to `FishBody`
- document change in TODO and CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path . --verbose .`
- `godot --headless --check-only --quit --path . --verbose .`
- `dotnet build fishtank/FishTank.sln --nologo`
- `dotnet build FISHYX3/FishyX3.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68645f1c4a248329bb0801f006b3181a