### PR TITLE
Fix fish visuals when debug overlay disabled

### DIFF
--- a/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
@@ -16,6 +16,7 @@ class_name FishRenderer
 
 const FR_NEAR_BRIGHT_SH: float = 1.00
 const FR_FAR_BRIGHT_SH: float = 0.55
+const FR_BASE_SIZE_SH: Vector2 = Vector2(80.0, 20.0)
 
 @export_group("Debug Visuals")
 @export_range(1.0, 20.0, 0.5, "suffix:px") var FR_dbg_point_radius_IN: float = 4.0
@@ -51,7 +52,7 @@ func _ready() -> void:
     FR_multimesh_SH.transform_format = MultiMesh.TRANSFORM_2D
     FR_multimesh_SH.use_colors = true
     var quad := QuadMesh.new()
-    quad.size = Vector2.ONE
+    quad.size = FR_BASE_SIZE_SH
     FR_multimesh_SH.mesh = quad
     FR_multimesh_SH.instance_count = 0
 


### PR DESCRIPTION
## Summary
- ensure MultiMesh fish quads are large enough to see

## Testing
- `gdformat --use-spaces=4 BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd`
- `gdlint BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd`
- `godot --headless --editor --import --quit --path BOIDFIsh/fishyfishyfishy --quiet` *(fails: `.NET: Failed to load project assembly`)*
- `godot --headless --check-only --quit --path BOIDFIsh/fishyfishyfishy --quiet` *(fails: parse errors)*
- `dotnet build --nologo` *(fails: no project)*

------
https://chatgpt.com/codex/tasks/task_e_68646b41628c8329b538ae6b68b23682