### PR TITLE
Implement non-uniform fish scaling

### DIFF
--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -35,3 +35,4 @@
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
 - Added inspector options for depth scale and opacity ranges in BoidSystem.
+- FishRenderer instances now scale width by archetype size and length by head-to-tail distance.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -26,3 +26,4 @@
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
 - [x] Expose depth scale and opacity ranges on BoidSystem
+- [x] Non-uniform scaling uses archetype width and snapshot distance


### PR DESCRIPTION
## Summary
- adjust `FishRenderer` to scale width using the archetype size and length by head‑to‑tail distance
- draw debug spines at the new scaled positions
- update TODO and CHANGELOG

## Testing
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene defined)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build fishtank/FishTank.sln --nologo`
- `dotnet format fishtank/FishTank.sln --verify-no-changes --no-restore --severity warn`

------
https://chatgpt.com/codex/tasks/task_e_68649d99b0408329a954ba02d277e748