### PR TITLE
Align fish mesh along spine

### DIFF
--- a/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
@@ -90,18 +90,22 @@ func _process(_delta: float) -> void:
         var scale: float = lerp(FR_front_scale_SH, FR_back_scale_SH, depth_ratio)
         var brightness: float = lerp(FR_NEAR_BRIGHT_SH, FR_FAR_BRIGHT_SH, depth_ratio)
 
+        var species_id: int = int(item["species_id"])
         var head2: Vector2 = Vector2(head.x, head.y)
         var tail2: Vector2 = Vector2(tail.x, tail.y)
-        var angle: float = (head2 - tail2).angle()
+
+        var length := head2.distance_to(tail2)
+        var arch := FR_boid_system_RD.FB_archetypes_IN[species_id]
+        var midpoint := (head2 + tail2) * 0.5
+        var angle := (tail2 - head2).angle()
 
         var xf := Transform2D.IDENTITY
-        xf = xf.scaled(Vector2(scale, scale))
+        xf = xf.scaled(Vector2(arch.FA_size_vec3_IN.x * scale, length * scale))
         xf = xf.rotated(angle)
-        xf = xf.translated(head2)
+        xf = xf.translated(midpoint)
 
         FR_multimesh_SH.set_instance_transform_2d(i, xf)
 
-        var species_id: int = int(item["species_id"])
         var palette_idx: int = 0
         if species_id < FR_boid_system_RD.FB_archetypes_IN.size():
             palette_idx = FR_boid_system_RD.FB_archetypes_IN[species_id].FA_palette_id_IN


### PR DESCRIPTION
## Summary
- orient fish quads using head and tail points
- keep depth tinting and debug drawing

## Testing
- `gdformat --use-spaces=4 $(git diff --name-only -- '*.gd')`
- `gdlint $(git diff --name-only -- '*.gd') || true`
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore FISHYX3/FishyX3.sln --no-cache --nologo`
- `dotnet build FISHYX3/FishyX3.sln --no-restore --nologo`
- `dotnet restore fishtank/FishTank.sln --no-cache --nologo`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6864a4e1b2508329a02ace17e230a218