### PR TITLE
Update renderer transform for midpoint

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -4,4 +4,5 @@
 - Tank size now updates from the viewport each frame.
 - Added built-in archetypes loading and override property in GameManager.
 - Debug overlay scales with depth to match fish size.
+- Renderer now aligns sprites precisely between head and tail.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -3,4 +3,5 @@
 - Review performance at larger fish counts.
 - Create built-in archetypes folder and load defaults automatically.
 - [x] Scale debug overlay by depth to match fish size.
+- [ ] Profile new midpoint transform for performance impact.
 

--- a/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
@@ -92,16 +92,23 @@ func _process(_delta: float) -> void:
 
         var head2: Vector2 = Vector2(head.x, head.y)
         var tail2: Vector2 = Vector2(tail.x, tail.y)
-        var angle: float = (head2 - tail2).angle()
+
+        var length: float = head2.distance_to(tail2)
+        var species_id: int = int(item["species_id"])
+        var arch: FishArchetype
+        if species_id < FR_boid_system_RD.FB_archetypes_IN.size():
+            arch = FR_boid_system_RD.FB_archetypes_IN[species_id]
+        else:
+            arch = FR_boid_system_RD.FB_archetypes_IN[0]
+        var midpoint: Vector2 = (head2 + tail2) * 0.5
+        var angle: float = (tail2 - head2).angle()
 
         var xf := Transform2D.IDENTITY
-        xf = xf.scaled(Vector2(scale, scale))
+        xf = xf.scaled(Vector2(arch.FA_size_vec3_IN.x * scale, length * scale))
         xf = xf.rotated(angle)
-        xf = xf.translated(head2)
+        xf = xf.translated(midpoint)
 
         FR_multimesh_SH.set_instance_transform_2d(i, xf)
-
-        var species_id: int = int(item["species_id"])
         var palette_idx: int = 0
         if species_id < FR_boid_system_RD.FB_archetypes_IN.size():
             palette_idx = FR_boid_system_RD.FB_archetypes_IN[species_id].FA_palette_id_IN


### PR DESCRIPTION
## Summary
- compute midpoint rotation and size from head and tail in `fish_renderer.gd`
- document renderer changes in CHANGE_LOG
- add TODO item to profile the transform

## Testing
- `gdformat --use-spaces=4 BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd`
- `gdlint BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd`
- `godot --headless --editor --import --quit --path BOIDFIsh/fishyfishyfishy --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/fishyfishyfishy --quiet`
- `dotnet build FISHYX3/FishyX3.sln --nologo`
- `dotnet build fishtank/FishTank.sln --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6864a4e1b2508329a02ace17e230a218