### PR TITLE
Align fish sprite scaling with distance

### DIFF
--- a/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
+++ b/BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd
@@ -92,16 +92,20 @@ func _process(_delta: float) -> void:
 
         var head2: Vector2 = Vector2(head.x, head.y)
         var tail2: Vector2 = Vector2(tail.x, tail.y)
-        var angle: float = (head2 - tail2).angle()
+
+        var length := head2.distance_to(tail2)
+        var species_id: int = int(item["species_id"])
+        var arch := FR_boid_system_RD.FB_archetypes_IN[species_id]
+        var midpoint := (head2 + tail2) * 0.5
+        var angle := (tail2 - head2).angle()
 
         var xf := Transform2D.IDENTITY
-        xf = xf.scaled(Vector2(scale, scale))
+        xf = xf.scaled(Vector2(arch.FA_size_vec3_IN.x * scale, length * scale))
         xf = xf.rotated(angle)
-        xf = xf.translated(head2)
+        xf = xf.translated(midpoint)
 
         FR_multimesh_SH.set_instance_transform_2d(i, xf)
 
-        var species_id: int = int(item["species_id"])
         var palette_idx: int = 0
         if species_id < FR_boid_system_RD.FB_archetypes_IN.size():
             palette_idx = FR_boid_system_RD.FB_archetypes_IN[species_id].FA_palette_id_IN

--- a/fishtank/CHANGELOG.md
+++ b/fishtank/CHANGELOG.md
@@ -35,3 +35,4 @@
 - Corrected fish rotation to follow travel direction.
 - Ensured dynamic squash realigns to current orientation.
 - Added inspector options for depth scale and opacity ranges in BoidSystem.
+- Updated fish_renderer to scale sprites based on head-to-tail distance.

--- a/fishtank/TODO.md
+++ b/fishtank/TODO.md
@@ -26,3 +26,4 @@
 - [x] Fix fish orientation drift
 - [x] Maintain dynamic squash alignment with orientation
 - [x] Expose depth scale and opacity ranges on BoidSystem
+- [x] Render fish by distance between head and tail for correct stretching


### PR DESCRIPTION
## Summary
- stretch fish renderer by head-to-tail length
- update TODO and CHANGELOG

## Testing
- `gdformat --use-spaces=4 BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd`
- `gdlint BOIDFIsh/fishyfishyfishy/scripts/renderer/fish_renderer.gd`
- `dotnet format fishtank/FishTank.csproj --verify-no-changes --severity error`
- `godot --headless --editor --import --quit --path fishtank --quiet`
- `godot --headless --check-only --quit --path fishtank --quiet`
- `dotnet build fishtank/FishTank.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6864a4e1b2508329a02ace17e230a218