### PR TITLE
Add softbody fish prototype

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -4,4 +4,5 @@
 - Tank size now updates from the viewport each frame.
 - Added built-in archetypes loading and override property in GameManager.
 - Debug overlay scales with depth to match fish size.
+- Added softbody_fish prototype under prototypes/
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -3,4 +3,5 @@
 - Review performance at larger fish counts.
 - Create built-in archetypes folder and load defaults automatically.
 - [x] Scale debug overlay by depth to match fish size.
+- [ ] Explore softbody fish prototype in prototypes/
 

--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -1,0 +1,5 @@
+# Softbody Fish Prototype
+
+Standalone Godot project demonstrating a simple soft-body fish.
+This prototype uses the coordinate layout from `SOFTBODYFISHPLAN.md`
+under `fishyfishyfishy` and applies basic spring physics each frame.

--- a/BOIDFIsh/prototypes/softbody_fish/project.godot
+++ b/BOIDFIsh/prototypes/softbody_fish/project.godot
@@ -1,0 +1,6 @@
+; Engine configuration file.
+config_version=5
+
+[application]
+config/name="SoftbodyFish"
+run/main_scene="res://scenes/SoftBodyFishPrototype.tscn"

--- a/BOIDFIsh/prototypes/softbody_fish/scenes/SoftBodyFishPrototype.tscn
+++ b/BOIDFIsh/prototypes/softbody_fish/scenes/SoftBodyFishPrototype.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scripts/SoftBodyFish.gd" type="Script" id="1"]
+
+[node name="SoftBodyFish" type="Node2D"]
+script = ExtResource("1")

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -1,0 +1,86 @@
+###############################################################
+# BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+# Key Classes      • SoftBodyFish – basic soft-body fish prototype
+# Key Functions    • _physics_process() – per-frame spring update
+# Critical Consts  • SB_COORDS_UP – initial node layout
+# Editor Exports   • SB_spring_strength_IN: float
+# Dependencies     • none
+# Last Major Rev   • 25-07-02 – initial creation
+###############################################################
+# gdlint:disable = class-variable-name,function-name,class-definitions-order
+class_name SoftBodyFish
+extends Node2D
+
+const SB_COORDS_UP := [
+    Vector2(4, 5.5),
+    Vector2(6, 6.6),
+    Vector2(9, 7.0),
+    Vector2(12, 5.4),
+    Vector2(14, 6.75),
+    Vector2(15, 7.0),
+    Vector2(15, 3.0),
+    Vector2(14, 3.25),
+    Vector2(12, 4.6),
+    Vector2(9, 3.0),
+    Vector2(6, 3.4),
+    Vector2(4, 4.5)
+]
+
+@export var SB_spring_strength_IN: float = 60.0
+@export var SB_radial_strength_IN: float = 20.0
+@export_range(0.0, 1.0, 0.01) var SB_damping_IN: float = 0.9
+@export var SB_gravity_IN: float = 0.0
+@export var SB_wobble_amp_IN: float = 0.5
+@export var SB_wobble_speed_IN: float = 2.0
+
+var SB_nodes_UP := []
+var SB_vels_UP := []
+var SB_rest_UP := []
+var SB_poly_node: Polygon2D
+var SB_time_UP: float = 0.0
+
+# Future expansion: head/tail controls
+var SB_head_ctrl_UP: Vector2 = Vector2.ZERO
+var SB_tail_ctrl_UP: Vector2 = Vector2.ZERO
+
+
+func _ready() -> void:
+    SB_rest_UP = SB_COORDS_UP.duplicate()
+    for coord in SB_rest_UP:
+        SB_nodes_UP.append(coord)
+        SB_vels_UP.append(Vector2.ZERO)
+    SB_poly_node = Polygon2D.new()
+    SB_poly_node.material = load("res://shaders/SoftBodyFishShader.tres")
+    add_child(SB_poly_node)
+    _update_polygon()
+
+
+func _physics_process(delta: float) -> void:
+    SB_time_UP += delta
+    var n: int = SB_nodes_UP.size()
+    for i in n:
+        var pos: Vector2 = SB_nodes_UP[i]
+        var prev: Vector2 = SB_nodes_UP[(i - 1 + n) % n]
+        var next: Vector2 = SB_nodes_UP[(i + 1) % n]
+        var rest: Vector2 = SB_rest_UP[i]
+        var spring: Vector2 = (next - pos) + (prev - pos)
+        spring *= SB_spring_strength_IN
+        var wobble_offset: Vector2 = (
+            Vector2(
+                sin(SB_time_UP * SB_wobble_speed_IN + float(i)),
+                cos(SB_time_UP * SB_wobble_speed_IN + float(i))
+            )
+            * SB_wobble_amp_IN
+        )
+        var radial: Vector2 = (rest + wobble_offset - pos) * SB_radial_strength_IN
+        var accel: Vector2 = spring + radial
+        accel.y += SB_gravity_IN
+        SB_vels_UP[i] += accel * delta
+        SB_vels_UP[i] *= SB_damping_IN
+        SB_nodes_UP[i] += SB_vels_UP[i] * delta
+    _update_polygon()
+
+
+func _update_polygon() -> void:
+    if SB_poly_node:
+        SB_poly_node.polygon = PackedVector2Array(SB_nodes_UP)

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd.uid
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd.uid
@@ -1,0 +1,1 @@
+uid://ci48m0igv0xil

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/SoftBodyFishShader.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/SoftBodyFishShader.gdshader
@@ -1,0 +1,14 @@
+shader_type canvas_item;
+
+uniform vec4 color_top = vec4(0.8, 0.9, 1.0, 1.0);
+uniform vec4 color_bottom = vec4(0.2, 0.4, 0.6, 1.0);
+uniform vec4 rim_color = vec4(1.0, 1.0, 1.0, 0.8);
+uniform float rim_width = 0.15;
+
+void fragment() {
+    vec2 center = vec2(0.5, 0.5);
+    float dist = length(UV - center) * 2.0;
+    float rim = smoothstep(1.0 - rim_width, 1.0, dist);
+    vec4 base = mix(color_top, color_bottom, UV.y);
+    COLOR = base + rim * rim_color;
+}

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/SoftBodyFishShader.gdshader.uid
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/SoftBodyFishShader.gdshader.uid
@@ -1,0 +1,1 @@
+uid://0n76ocpp0ysm

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/SoftBodyFishShader.tres
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/SoftBodyFishShader.tres
@@ -1,0 +1,6 @@
+[gd_resource type="ShaderMaterial" format=3]
+
+[ext_resource type="Shader" path="res://shaders/SoftBodyFishShader.gdshader" id="1"]
+
+[resource]
+shader = ExtResource("1")


### PR DESCRIPTION
## Summary
- create `softbody_fish` standalone project under `BOIDFIsh/prototypes`
- add minimal shader and node-based softbody physics script
- document prototype in changelog and todo lists

## Testing
- `gdlint BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd`
- `godot --headless --editor --import --quit --path FISHYX3 --quiet`
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path FISHYX3 --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet restore FISHYX3/FishyX3.sln --nologo`
- `dotnet build FISHYX3/FishyX3.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68659e057ce4832989967dc83696368b