### PR TITLE
Add draggable softbody fish controls

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -5,4 +5,5 @@
 - Added built-in archetypes loading and override property in GameManager.
 - Debug overlay scales with depth to match fish size.
 - Added softbody fish prototype under `prototypes/softbody_fish`.
+- Enlarged softbody fish, added draggable head/tail controls and extra cross-braces.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -3,5 +3,6 @@
 - Review performance at larger fish counts.
 - Create built-in archetypes folder and load defaults automatically.
 - [x] Scale debug overlay by depth to match fish size.
-- Add softbody fish prototype under `prototypes/softbody_fish`.
+- [x] Add softbody fish prototype under `prototypes/softbody_fish`.
+- [ ] Fine-tune spring parameters for cross-braced SoftBodyFish.
 

--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -2,3 +2,9 @@
 
 Experimental soft body fish based on a spring-mesh approach.
 This folder contains a minimal Godot project for quick iteration.
+
+The fish is scaled up 15× and centered on load. Drag the exposed
+`HeadControl` and `TailControl` nodes in the editor or at runtime to
+stretch the mesh. Additional cross-brace springs keep the body stable
+while separate spring strength exports allow tuning of the head, tail
+and body stiffness individually.

--- a/BOIDFIsh/prototypes/softbody_fish/scenes/SoftBodyFishPrototype.tscn
+++ b/BOIDFIsh/prototypes/softbody_fish/scenes/SoftBodyFishPrototype.tscn
@@ -4,3 +4,8 @@
 
 [node name="SoftBodyFish" type="Node2D"]
 script = ExtResource("1")
+
+[node name="HeadControl" type="Node2D" parent="."]
+
+[node name="TailControl" type="Node2D" parent="."]
+

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -4,7 +4,7 @@
 # Key Classes      • SoftBodyFish – simple soft-body fish demo
 # Key Functions    • _physics_step() – per-node spring physics
 # Critical Consts  • FB_COORDS – initial node positions
-# Editor Exports   • FB_spring_strength_IN: float
+# Editor Exports   • FB_body_spring_strength_IN: float
 # Dependencies     • shaders/soft_body_fish.gdshader
 # Last Major Rev   • 24-04-30 – initial prototype
 ###############################################################
@@ -28,7 +28,14 @@ const FB_COORDS: Array[Vector2] = [
     Vector2(4, 5.5)
 ]
 
-@export var FB_spring_strength_IN: float = 10.0
+const HEAD_INDICES: PackedInt32Array = PackedInt32Array([0, 1, 11, 12])
+const TAIL_INDICES: PackedInt32Array = PackedInt32Array([4, 5, 6, 7])
+const CROSS_PAIRS: Array = [[2, 9], [3, 8]]
+
+@export var FB_body_spring_strength_IN: float = 10.0
+@export var FB_head_spring_strength_IN: float = 12.0
+@export var FB_tail_spring_strength_IN: float = 12.0
+@export var FB_display_scale_IN: float = 15.0
 @export var FB_radial_strength_IN: float = 5.0
 @export_range(0.5, 1.0, 0.01) var FB_damping_IN: float = 0.9
 @export var FB_gravity_IN: float = 0.0
@@ -41,13 +48,21 @@ var FB_rest_nodes_SH: Array[Vector2] = []
 var FB_head_ctrl_UP: Vector2 = Vector2.ZERO
 var FB_tail_ctrl_UP: Vector2 = Vector2.ZERO
 var _mat: ShaderMaterial
+var _dragging_head: bool = false
+var _dragging_tail: bool = false
+
+@onready var head_control: Node2D = $HeadControl
+@onready var tail_control: Node2D = $TailControl
 
 
 func _ready() -> void:
     _init_nodes()
+    position = get_viewport_rect().size * 0.5
     _mat = ShaderMaterial.new()
     _mat.shader = load("res://shaders/soft_body_fish.gdshader")
     material = _mat
+    head_control.position = FB_nodes_UP[0]
+    tail_control.position = FB_nodes_UP[5]
 
 
 func _init_nodes() -> void:
@@ -55,14 +70,43 @@ func _init_nodes() -> void:
     FB_node_vels_UP.clear()
     FB_rest_nodes_SH.clear()
     for pt in FB_COORDS:
-        FB_nodes_UP.append(pt)
+        var p: Vector2 = pt * FB_display_scale_IN
+        FB_nodes_UP.append(p)
         FB_node_vels_UP.append(Vector2.ZERO)
-        FB_rest_nodes_SH.append(pt)
+        FB_rest_nodes_SH.append(p)
 
 
 func _process(delta: float) -> void:
+    _update_cursor()
     _physics_step(delta)
     queue_redraw()
+
+
+func _input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+        if event.pressed:
+            if head_control.global_position.distance_to(event.position) < 10.0:
+                _dragging_head = true
+            elif tail_control.global_position.distance_to(event.position) < 10.0:
+                _dragging_tail = true
+        else:
+            _dragging_head = false
+            _dragging_tail = false
+    elif event is InputEventMouseMotion:
+        if _dragging_head:
+            head_control.position += event.relative
+        elif _dragging_tail:
+            tail_control.position += event.relative
+
+
+func _update_cursor() -> void:
+    var mouse_pos: Vector2 = get_global_mouse_position()
+    var cursor := Input.CURSOR_ARROW
+    if head_control.global_position.distance_to(mouse_pos) < 10.0:
+        cursor = Input.CURSOR_POINTING_HAND
+    elif tail_control.global_position.distance_to(mouse_pos) < 10.0:
+        cursor = Input.CURSOR_POINTING_HAND
+    Input.set_default_cursor_shape(cursor)
 
 
 func _physics_step(delta: float) -> void:
@@ -74,11 +118,21 @@ func _physics_step(delta: float) -> void:
         var pos: Vector2 = FB_nodes_UP[i]
         var vel: Vector2 = FB_node_vels_UP[i]
         var base: Vector2 = FB_rest_nodes_SH[i]
+        if i in HEAD_INDICES:
+            base = head_control.position
+        elif i in TAIL_INDICES:
+            base = tail_control.position
         var wob: float = sin(time_now * 0.8 + float(i)) * FB_wobble_amp_IN
         var breath: float = sin(time_now + float(i) * 0.1) * FB_breath_amp_IN
         var target: Vector2 = base + Vector2(0, wob + breath)
 
-        var spring: Vector2 = ((prev + next) * 0.5 - pos) * FB_spring_strength_IN * delta
+        var spring_strength: float = FB_body_spring_strength_IN
+        if i in HEAD_INDICES:
+            spring_strength = FB_head_spring_strength_IN
+        elif i in TAIL_INDICES:
+            spring_strength = FB_tail_spring_strength_IN
+
+        var spring: Vector2 = ((prev + next) * 0.5 - pos) * spring_strength * delta
         var radial: Vector2 = (target - pos) * FB_radial_strength_IN * delta
         var grav: Vector2 = Vector2.DOWN * FB_gravity_IN * delta
         vel += spring + radial + grav
@@ -86,6 +140,15 @@ func _physics_step(delta: float) -> void:
         pos += vel * delta
         FB_nodes_UP[i] = pos
         FB_node_vels_UP[i] = vel
+
+    for pair in CROSS_PAIRS:
+        var a: int = pair[0]
+        var b: int = pair[1]
+        var pa: Vector2 = FB_nodes_UP[a]
+        var pb: Vector2 = FB_nodes_UP[b]
+        var mid: Vector2 = (pa + pb) * 0.5
+        FB_node_vels_UP[a] += (mid - pa) * FB_body_spring_strength_IN * delta
+        FB_node_vels_UP[b] += (mid - pb) * FB_body_spring_strength_IN * delta
 
 
 func _draw() -> void:


### PR DESCRIPTION
## Summary
- scale softbody fish 15x and center on start
- expose head/tail control nodes and individual spring strengths
- add cross-brace springs for stability
- update docs and changelog

## Testing
- `gdlint $(git diff --name-only --cached -- '*.gd')`
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene defined)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo` *(fails: no project or solution file)*
- `bash -c 'dotnet format --verify-no-changes --nologo --severity hidden || { echo "🛑  C# style violations"; exit 1; }' || true`

------
https://chatgpt.com/codex/tasks/task_e_6865d6fb3d8483299cd5e24f0205ee0c