### PR TITLE
Add draggable softbody fish controls

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -5,4 +5,5 @@
 - Added built-in archetypes loading and override property in GameManager.
 - Debug overlay scales with depth to match fish size.
 - Added softbody fish prototype under `prototypes/softbody_fish`.
+- Softbody fish now supports draggable head and tail controls.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -4,4 +4,5 @@
 - Create built-in archetypes folder and load defaults automatically.
 - [x] Scale debug overlay by depth to match fish size.
 - Add softbody fish prototype under `prototypes/softbody_fish`.
+- [ ] Expose spring tuning and draggable controls in softbody fish prototype.
 

--- a/BOIDFIsh/prototypes/softbody_fish/scenes/SoftBodyFishPrototype.tscn
+++ b/BOIDFIsh/prototypes/softbody_fish/scenes/SoftBodyFishPrototype.tscn
@@ -4,3 +4,9 @@
 
 [node name="SoftBodyFish" type="Node2D"]
 script = ExtResource("1")
+FB_head_control_IN = NodePath("HeadControl")
+FB_tail_control_IN = NodePath("TailControl")
+
+[node name="HeadControl" type="Node2D" parent="."]
+
+[node name="TailControl" type="Node2D" parent="."]

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -12,6 +12,8 @@
 class_name SoftBodyFish
 extends Node2D
 
+const FB_SCALE: float = 15.0
+
 const FB_COORDS: Array[Vector2] = [
     Vector2(4, 5.5),
     Vector2(6, 6.6),
@@ -28,12 +30,19 @@ const FB_COORDS: Array[Vector2] = [
     Vector2(4, 5.5)
 ]
 
+const FB_DRAG_RADIUS: float = 20.0
+
 @export var FB_spring_strength_IN: float = 10.0
+@export var FB_head_anchor_strength_IN: float = 20.0
+@export var FB_tail_anchor_strength_IN: float = 20.0
 @export var FB_radial_strength_IN: float = 5.0
 @export_range(0.5, 1.0, 0.01) var FB_damping_IN: float = 0.9
 @export var FB_gravity_IN: float = 0.0
 @export var FB_wobble_amp_IN: float = 0.4
 @export var FB_breath_amp_IN: float = 0.2
+
+@export var FB_head_control_IN: Node2D
+@export var FB_tail_control_IN: Node2D
 
 var FB_nodes_UP: Array[Vector2] = []
 var FB_node_vels_UP: Array[Vector2] = []
@@ -41,6 +50,7 @@ var FB_rest_nodes_SH: Array[Vector2] = []
 var FB_head_ctrl_UP: Vector2 = Vector2.ZERO
 var FB_tail_ctrl_UP: Vector2 = Vector2.ZERO
 var _mat: ShaderMaterial
+var _drag_node: Node2D
 
 
 func _ready() -> void:
@@ -48,6 +58,11 @@ func _ready() -> void:
     _mat = ShaderMaterial.new()
     _mat.shader = load("res://shaders/soft_body_fish.gdshader")
     material = _mat
+    position = get_viewport_rect().size * 0.5
+    if FB_head_control_IN:
+        FB_head_control_IN.position = _calc_head_pos()
+    if FB_tail_control_IN:
+        FB_tail_control_IN.position = _calc_tail_pos()
 
 
 func _init_nodes() -> void:
@@ -55,14 +70,43 @@ func _init_nodes() -> void:
     FB_node_vels_UP.clear()
     FB_rest_nodes_SH.clear()
     for pt in FB_COORDS:
-        FB_nodes_UP.append(pt)
+        var scaled: Vector2 = pt * FB_SCALE
+        FB_nodes_UP.append(scaled)
         FB_node_vels_UP.append(Vector2.ZERO)
-        FB_rest_nodes_SH.append(pt)
+        FB_rest_nodes_SH.append(scaled)
+
+
+func _calc_head_pos() -> Vector2:
+    return (FB_rest_nodes_SH[5] + FB_rest_nodes_SH[6]) * 0.5
+
+
+func _calc_tail_pos() -> Vector2:
+    return (FB_rest_nodes_SH[0] + FB_rest_nodes_SH[11]) * 0.5
 
 
 func _process(delta: float) -> void:
     _physics_step(delta)
     queue_redraw()
+    _update_cursor()
+
+
+func _input(event: InputEvent) -> void:
+    if not FB_head_control_IN or not FB_tail_control_IN:
+        return
+    if event is InputEventMouseButton:
+        var mb := event as InputEventMouseButton
+        var local_pos: Vector2 = to_local(mb.position)
+        if mb.button_index == MOUSE_BUTTON_LEFT:
+            if mb.pressed:
+                if FB_head_control_IN.position.distance_to(local_pos) <= FB_DRAG_RADIUS:
+                    _drag_node = FB_head_control_IN
+                elif FB_tail_control_IN.position.distance_to(local_pos) <= FB_DRAG_RADIUS:
+                    _drag_node = FB_tail_control_IN
+            else:
+                _drag_node = null
+    elif event is InputEventMouseMotion and _drag_node:
+        var mm := event as InputEventMouseMotion
+        _drag_node.position = to_local(mm.position)
 
 
 func _physics_step(delta: float) -> void:
@@ -81,11 +125,40 @@ func _physics_step(delta: float) -> void:
         var spring: Vector2 = ((prev + next) * 0.5 - pos) * FB_spring_strength_IN * delta
         var radial: Vector2 = (target - pos) * FB_radial_strength_IN * delta
         var grav: Vector2 = Vector2.DOWN * FB_gravity_IN * delta
+        if FB_head_control_IN and i in [5, 6]:
+            vel += (FB_head_control_IN.position - pos) * FB_head_anchor_strength_IN * delta
+        if FB_tail_control_IN and i in [0, 11]:
+            vel += (FB_tail_control_IN.position - pos) * FB_tail_anchor_strength_IN * delta
         vel += spring + radial + grav
         vel *= FB_damping_IN
         pos += vel * delta
         FB_nodes_UP[i] = pos
         FB_node_vels_UP[i] = vel
+
+    _apply_diag_spring(2, 9, delta)
+    _apply_diag_spring(3, 8, delta)
+
+
+func _apply_diag_spring(a: int, b: int, delta: float) -> void:
+    var pos_a: Vector2 = FB_nodes_UP[a]
+    var pos_b: Vector2 = FB_nodes_UP[b]
+    var diff: Vector2 = pos_b - pos_a
+    var spring: Vector2 = diff * FB_spring_strength_IN * delta
+    FB_node_vels_UP[a] += spring
+    FB_node_vels_UP[b] -= spring
+
+
+func _update_cursor() -> void:
+    if not FB_head_control_IN or not FB_tail_control_IN:
+        return
+    var mpos: Vector2 = to_local(get_viewport().get_mouse_position())
+    if (
+        FB_head_control_IN.position.distance_to(mpos) <= FB_DRAG_RADIUS
+        or FB_tail_control_IN.position.distance_to(mpos) <= FB_DRAG_RADIUS
+    ):
+        Input.set_default_cursor_shape(Input.CURSOR_POINTING_HAND)
+    else:
+        Input.set_default_cursor_shape(Input.CURSOR_ARROW)
 
 
 func _draw() -> void:


### PR DESCRIPTION
## Summary
- enlarge softbody fish prototype
- expose head and tail spring controls
- add draggable head and tail nodes with mouse cursor feedback
- add diagonal springs for stability
- update changelog and TODO

## Testing
- `bash .codex/fix_indent.sh BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd`
- `gdlint BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd`
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6865d6fb3d8483299cd5e24f0205ee0c