### PR TITLE
Implement resilient softbody fish rendering

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -5,6 +5,8 @@
 - Added built-in archetypes loading and override property in GameManager.
 - Debug overlay scales with depth to match fish size.
 - Added softbody fish prototype under `prototypes/softbody_fish`.
+- Softbody fish rendering now uses Curve2D smoothing with bisection fallback to
+  avoid polygon pop-out.
 - Softbody fish can be dragged via head and tail gizmos; spring strength controls
   for head and tail added.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -4,5 +4,6 @@
 - Create built-in archetypes folder and load defaults automatically.
 - [x] Scale debug overlay by depth to match fish size.
 - Add softbody fish prototype under `prototypes/softbody_fish`.
+- [x] Ensure softbody fish polygon remains valid with bisection fallback.
 - [x] Add gizmo controls for softbody fish head and tail.
 


### PR DESCRIPTION
## Summary
- keep last valid node positions for the softbody fish
- bisect toward a valid polygon when mesh triangulation fails
- tessellate fish outline with `Curve2D` for smoother shapes
- document the new fallback behaviour

## Testing
- `gdlint BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd`
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene defined)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e5c83e7c8329a328897b6a8dcb4f