### PR TITLE
Smooth Catmull-Rom outline for softbody fish

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -7,4 +7,6 @@
 - Added softbody fish prototype under `prototypes/softbody_fish`.
 - Softbody fish can be dragged via head and tail gizmos; spring strength controls
   for head and tail added.
+- Softbody fish outline now uses Catmull-Rom curve smoothing with adjustable
+  handle ratio and tessellation steps.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -5,4 +5,6 @@
 - [x] Scale debug overlay by depth to match fish size.
 - Add softbody fish prototype under `prototypes/softbody_fish`.
 - [x] Add gizmo controls for softbody fish head and tail.
+- [x] Implement Catmull-Rom smoothing for softbody fish outline.
+- Tune smoothing handle ratio and tessellation steps for performance testing.
 


### PR DESCRIPTION
## Summary
- smooth SoftBodyFish outline with Curve2D tessellation
- add handle/tessellation tunables
- update changelog and todo

## Testing
- `gdlint BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd`
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet build FISHYX3/FishyX3.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6865ed1156a08329a740958a26972bc6