### PR TITLE
Softbody fish curvature improvements

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -7,4 +7,6 @@
 - Added softbody fish prototype under `prototypes/softbody_fish`.
 - Softbody fish can be dragged via head and tail gizmos; spring strength controls
   for head and tail added.
+- Softbody fish now uses twice as many points and reduced spring strength for a
+  smoother curved body.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -5,4 +5,5 @@
 - [x] Scale debug overlay by depth to match fish size.
 - Add softbody fish prototype under `prototypes/softbody_fish`.
 - [x] Add gizmo controls for softbody fish head and tail.
+- [x] Double softbody fish point count and relax springs for smoother shape.
 

--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -2,3 +2,5 @@
 
 Experimental soft body fish based on a spring-mesh approach.
 This folder contains a minimal Godot project for quick iteration.
+The latest update doubles the polygon vertex count and relaxes spring
+strengths to produce a smoother, more curved fish.

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -29,14 +29,14 @@ const FB_COORDS: Array[Vector2] = [
 ]
 const FB_SCALE: float = 15.0
 const FB_HEAD_IDX: int = 0
-const FB_TAIL_IDXS: Array[int] = [5, 6]
-const FB_DIAGONALS: Array = [[2, 9], [3, 8]]
+const FB_TAIL_IDXS: Array[int] = [10, 12]
+const FB_DIAGONALS: Array = [[4, 18], [6, 16]]
 
-@export var FB_spring_strength_IN: float = 10.0
-@export var FB_head_strength_IN: float = 12.0
-@export var FB_tail_strength_IN: float = 8.0
-@export var FB_diag_strength_IN: float = 10.0
-@export var FB_radial_strength_IN: float = 5.0
+@export var FB_spring_strength_IN: float = 8.0
+@export var FB_head_strength_IN: float = 10.0
+@export var FB_tail_strength_IN: float = 6.0
+@export var FB_diag_strength_IN: float = 8.0
+@export var FB_radial_strength_IN: float = 4.0
 @export_range(0.5, 1.0, 0.01) var FB_damping_IN: float = 0.9
 @export var FB_gravity_IN: float = 0.0
 @export var FB_wobble_amp_IN: float = 0.4
@@ -68,8 +68,16 @@ func _init_nodes() -> void:
     FB_nodes_UP.clear()
     FB_node_vels_UP.clear()
     FB_rest_nodes_SH.clear()
+    var doubled: Array[Vector2] = []
+    for i in range(FB_COORDS.size() - 1):
+        var a: Vector2 = FB_COORDS[i]
+        var b: Vector2 = FB_COORDS[i + 1]
+        doubled.append(a)
+        doubled.append((a + b) * 0.5)
+    doubled.append(FB_COORDS[FB_COORDS.size() - 1])
+
     var scaled: Array[Vector2] = []
-    for pt in FB_COORDS:
+    for pt in doubled:
         scaled.append(pt * FB_SCALE)
     var centroid: Vector2 = Vector2.ZERO
     for i in range(scaled.size() - 1):


### PR DESCRIPTION
## Summary
- double the soft body fish's node count at runtime
- lower the default spring strengths
- note smoother shape in softbody fish README
- record the enhancement in CHANGE_LOG and TODO

## Testing
- `gdlint BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd || true`
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project)*

------
https://chatgpt.com/codex/tasks/task_e_686722e363048329bda4668b12c30d63