### PR TITLE
Improve softbody fish prototype

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -7,4 +7,5 @@
 - Added softbody fish prototype under `prototypes/softbody_fish`.
 - Softbody fish can be dragged via head and tail gizmos; spring strength controls
   for head and tail added.
+- Softbody fish now uses twice as many nodes with weaker springs for a smoother curve.
 

--- a/BOIDFIsh/TODO.md
+++ b/BOIDFIsh/TODO.md
@@ -5,4 +5,5 @@
 - [x] Scale debug overlay by depth to match fish size.
 - Add softbody fish prototype under `prototypes/softbody_fish`.
 - [x] Add gizmo controls for softbody fish head and tail.
+- [ ] Increase softbody fish vertex count for smoother shape.
 

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -14,28 +14,40 @@ extends Node2D
 
 const FB_COORDS: Array[Vector2] = [
     Vector2(4, 5.5),
+    Vector2(5, 6.05),
     Vector2(6, 6.6),
-    Vector2(9, 7.0),
+    Vector2(7.5, 6.8),
+    Vector2(9, 7),
+    Vector2(10.5, 6.2),
     Vector2(12, 5.4),
+    Vector2(13, 6.075),
     Vector2(14, 6.75),
-    Vector2(15, 7.0),
-    Vector2(15, 3.0),
+    Vector2(14.5, 6.875),
+    Vector2(15, 7),
+    Vector2(15, 5),
+    Vector2(15, 3),
+    Vector2(14.5, 3.125),
     Vector2(14, 3.25),
+    Vector2(13, 3.925),
     Vector2(12, 4.6),
-    Vector2(9, 3.0),
+    Vector2(10.5, 3.8),
+    Vector2(9, 3),
+    Vector2(7.5, 3.2),
     Vector2(6, 3.4),
+    Vector2(5, 3.95),
     Vector2(4, 4.5),
+    Vector2(4, 5),
     Vector2(4, 5.5)
 ]
 const FB_SCALE: float = 15.0
 const FB_HEAD_IDX: int = 0
-const FB_TAIL_IDXS: Array[int] = [5, 6]
-const FB_DIAGONALS: Array = [[2, 9], [3, 8]]
+const FB_TAIL_IDXS: Array[int] = [10, 12]
+const FB_DIAGONALS: Array = [[4, 18], [6, 16]]
 
-@export var FB_spring_strength_IN: float = 10.0
+@export var FB_spring_strength_IN: float = 8.0
 @export var FB_head_strength_IN: float = 12.0
 @export var FB_tail_strength_IN: float = 8.0
-@export var FB_diag_strength_IN: float = 10.0
+@export var FB_diag_strength_IN: float = 8.0
 @export var FB_radial_strength_IN: float = 5.0
 @export_range(0.5, 1.0, 0.01) var FB_damping_IN: float = 0.9
 @export var FB_gravity_IN: float = 0.0


### PR DESCRIPTION
## Summary
- make fish body polygon smoother by doubling verts
- relax spring strengths for softer motion
- update TODO and CHANGE_LOG

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet build FISHYX3/FishyX3.sln --nologo`
- `dotnet build fishtank/FishTank.sln --nologo`


------
https://chatgpt.com/codex/tasks/task_e_686722e363048329bda4668b12c30d63