### PR TITLE
Implement precomputed triangulation for SoftBodyFish

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -9,4 +9,5 @@
   for head and tail added.
 - Softbody fish now uses twice as many points with lower spring strength for a smoother shape.
 - Updated softbody fish vertex coordinates for improved accuracy.
+- Softbody fish renderer uses precomputed triangulation to avoid runtime errors.
 


### PR DESCRIPTION
## Summary
- update SoftBodyFish.gd to precompute polygon triangle indices
- render with `RenderingServer.canvas_item_add_triangle_array`
- document change in `CHANGE_LOG.md`

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `gdlint BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd`

------
https://chatgpt.com/codex/tasks/task_e_6868d0d168648329851ae23bcaad5c5a