### PR TITLE
Add dynamic shading for softbody fish

### DIFF
--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -2,3 +2,6 @@
 
 Experimental soft body fish based on a spring-mesh approach.
 This folder contains a minimal Godot project for quick iteration.
+The shader now generates a dynamic fake normal based on the current
+polygon bounds so that the body appears rounded even as the mesh
+deforms.

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -169,8 +169,26 @@ func _physics_step(delta: float) -> void:
 func _draw() -> void:
     var points: PackedVector2Array = PackedVector2Array(FB_nodes_UP)
     var uvs: PackedVector2Array = PackedVector2Array()
+    var min_x: float = FB_nodes_UP[0].x
+    var max_x: float = FB_nodes_UP[0].x
+    var min_y: float = FB_nodes_UP[0].y
+    var max_y: float = FB_nodes_UP[0].y
     for p in FB_nodes_UP:
-        uvs.append(p * 0.05 + Vector2(0.5, 0.5))
+        min_x = min(min_x, p.x)
+        max_x = max(max_x, p.x)
+        min_y = min(min_y, p.y)
+        max_y = max(max_y, p.y)
+    var half_ext: Vector2 = Vector2((max_x - min_x) * 0.5, (max_y - min_y) * 0.5)
+    if half_ext.x == 0.0:
+        half_ext.x = 1.0
+    if half_ext.y == 0.0:
+        half_ext.y = 1.0
+    var center: Vector2 = Vector2(min_x + max_x, min_y + max_y) * 0.5
+    var aspect: Vector2 = half_ext / max(half_ext.x, half_ext.y)
+    _mat.set_shader_parameter("shape_aspect", aspect)
+    for p in FB_nodes_UP:
+        var uv: Vector2 = (p - center) / (half_ext * 2.0) + Vector2(0.5, 0.5)
+        uvs.append(uv)
     if _tri_indices.is_empty():
         # Fallback if initial triangulation failed
         draw_polyline(points, Color.WHITE, 2.0, true)

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
@@ -2,9 +2,17 @@ shader_type canvas_item;
 
 uniform vec4 top_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
 uniform vec4 bottom_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
+uniform vec2 shape_aspect = vec2(1.0, 1.0);
 
 void fragment() {
-    float rim = smoothstep(0.8, 1.0, 1.0 - length(UV * 2.0 - vec2(1.0)));
+    vec2 local = (UV - vec2(0.5)) * 2.0 * shape_aspect;
+    vec2 scaled = local * vec2(0.6, 1.0);
+    float z = sqrt(max(0.0, 1.0 - dot(scaled, scaled)));
+    vec3 normal = normalize(vec3(scaled, z));
+    vec3 light_dir = normalize(vec3(-0.3, -0.4, 0.9));
+    float diff = clamp(dot(normal, light_dir), 0.0, 1.0);
+    float rim = smoothstep(0.8, 1.0, 1.0 - length(local));
     vec4 col = mix(bottom_color, top_color, UV.y);
-    COLOR = col + vec4(vec3(rim), 0.0);
+    vec3 lit = col.rgb * diff + vec3(rim);
+    COLOR = vec4(lit, col.a);
 }


### PR DESCRIPTION
## Summary
- compute per-frame UV bounds in soft body fish
- pass aspect ratio to shader and generate fake normals
- document the new dynamic shading setup

## Testing
- `gdlint $(git diff --name-only -- '*.gd')`
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`
- `dotnet format BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --verify-no-changes --verbosity quiet`

------
https://chatgpt.com/codex/tasks/task_e_6868db093adc832982db71807141bb91