### PR TITLE
Add fake 3D normal shader for softbody fish

### DIFF
--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -169,8 +169,23 @@ func _physics_step(delta: float) -> void:
 func _draw() -> void:
     var points: PackedVector2Array = PackedVector2Array(FB_nodes_UP)
     var uvs: PackedVector2Array = PackedVector2Array()
+
+    var min_p: Vector2 = Vector2.INF
+    var max_p: Vector2 = -Vector2.INF
     for p in FB_nodes_UP:
-        uvs.append(p * 0.05 + Vector2(0.5, 0.5))
+        min_p.x = min(min_p.x, p.x)
+        min_p.y = min(min_p.y, p.y)
+        max_p.x = max(max_p.x, p.x)
+        max_p.y = max(max_p.y, p.y)
+    var center: Vector2 = (min_p + max_p) * 0.5
+    var extents: Vector2 = (max_p - min_p) * 0.5
+    if extents.x == 0.0:
+        extents.x = 1.0
+    if extents.y == 0.0:
+        extents.y = 1.0
+    for p in FB_nodes_UP:
+        var uv: Vector2 = (p - center) / extents * 0.5 + Vector2(0.5, 0.5)
+        uvs.append(uv)
     if _tri_indices.is_empty():
         # Fallback if initial triangulation failed
         draw_polyline(points, Color.WHITE, 2.0, true)

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
@@ -1,10 +1,27 @@
 shader_type canvas_item;
 
+///////////////////////////////////////////////////////////////
+// BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+// Key Functions    • fragment() – fake 3D lighting for soft-body fish
+// Critical Consts  • none
+// Editor Exports   • top_color, bottom_color
+// Dependencies     • none
+// Last Major Rev   • 24-05-05 – added fake normal lighting
+///////////////////////////////////////////////////////////////
+
 uniform vec4 top_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
 uniform vec4 bottom_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
 
+uniform float x_roundness = 0.4; // front/back bulge intensity
+uniform float y_roundness = 1.0; // top/bottom bulge intensity
+uniform vec3 light_dir = vec3(-0.2, -0.3, 1.0);
+
 void fragment() {
-    float rim = smoothstep(0.8, 1.0, 1.0 - length(UV * 2.0 - vec2(1.0)));
+    vec2 local = UV * 2.0 - vec2(1.0);
+    vec3 normal = normalize(vec3(local.x * x_roundness, local.y * y_roundness, 1.0));
+    float light = max(dot(normal, normalize(light_dir)), 0.0);
+    float rim = smoothstep(0.6, 1.0, 1.0 - length(local));
     vec4 col = mix(bottom_color, top_color, UV.y);
+    col.rgb *= light * 0.8 + 0.2;
     COLOR = col + vec4(vec3(rim), 0.0);
 }


### PR DESCRIPTION
## Summary
- update fish shader to calculate fake normals with configurable roundness
- compute per-vertex UVs from live mesh bounds to adapt lighting

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6868db093adc832982db71807141bb91