### PR TITLE
Add volumetric fish shader

### DIFF
--- a/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
@@ -1,10 +1,21 @@
 shader_type canvas_item;
 
+uniform vec2 body_radius = vec2(1.0, 0.6);
+uniform float bulge_power = 2.0;
+uniform vec3 light_dir = vec3(0.2, -0.7, 1.0);
+
 uniform vec4 top_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
 uniform vec4 bottom_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
 
 void fragment() {
-    float rim = smoothstep(0.8, 1.0, 1.0 - length(UV * 2.0 - vec2(1.0)));
+    vec2 norm_uv = (UV - vec2(0.5)) / body_radius;
+    float dist = length(norm_uv);
+    float height = pow(max(1.0 - dist, 0.0), bulge_power);
+
+    vec3 normal = normalize(vec3(norm_uv, height));
+    float shade = clamp(dot(normal, normalize(light_dir)), 0.0, 1.0);
+    float rim = smoothstep(0.85, 1.0, height);
+
     vec4 col = mix(bottom_color, top_color, UV.y);
-    COLOR = col + vec4(vec3(rim), 0.0);
+    COLOR = col * (0.6 + 0.4 * shade) + vec4(vec3(rim), 0.0);
 }


### PR DESCRIPTION
## Summary
- add a fake 3D lighting shader for softbody fish

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6868dffd6b44832993d162e743709c76