### PR TITLE
Add dynamic bulge shading for softbody fish

### DIFF
--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -76,12 +76,28 @@ var _mat: ShaderMaterial
 var _tri_indices: PackedInt32Array = PackedInt32Array()
 
 
+func _update_body_radius() -> void:
+    var min_x: float = INF
+    var max_x: float = -INF
+    var min_y: float = INF
+    var max_y: float = -INF
+    for p in FB_nodes_UP:
+        min_x = min(min_x, p.x)
+        max_x = max(max_x, p.x)
+        min_y = min(min_y, p.y)
+        max_y = max(max_y, p.y)
+    var radius_x: float = (max_x - min_x) * 0.025
+    var radius_y: float = (max_y - min_y) * 0.025
+    _mat.set_shader_parameter("body_radius", Vector2(radius_x, radius_y))
+
+
 func _ready() -> void:
     _init_nodes()
     position = get_viewport_rect().size * 0.5
     _mat = ShaderMaterial.new()
     _mat.shader = load("res://shaders/soft_body_fish.gdshader")
     material = _mat
+    _update_body_radius()
     _precompute_triangles()
     set_process_input(true)
 
@@ -127,6 +143,7 @@ func _process(delta: float) -> void:
     _physics_step(delta)
     FB_head_node_RD.position = FB_nodes_UP[FB_HEAD_IDX]
     FB_tail_node_RD.position = (FB_nodes_UP[FB_TAIL_IDXS[0]] + FB_nodes_UP[FB_TAIL_IDXS[1]]) * 0.5
+    _update_body_radius()
     queue_redraw()
 
 

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
@@ -2,9 +2,17 @@ shader_type canvas_item;
 
 uniform vec4 top_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
 uniform vec4 bottom_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
+uniform vec2 body_radius = vec2(0.35, 0.15);
+uniform float bulge_power = 2.0;
+uniform vec3 light_dir = vec3(0.2, -0.7, 1.0);
 
 void fragment() {
-    float rim = smoothstep(0.8, 1.0, 1.0 - length(UV * 2.0 - vec2(1.0)));
+    vec2 norm_uv = (UV - vec2(0.5)) / body_radius;
+    float dist = length(norm_uv);
+    float height = pow(1.0 - clamp(dist, 0.0, 1.0), bulge_power);
+    vec3 normal = normalize(vec3(norm_uv.x, norm_uv.y, height));
+    float shade = clamp(dot(normal, normalize(light_dir)), 0.0, 1.0);
+    float rim = smoothstep(0.8, 1.0, 1.0 - dist);
     vec4 col = mix(bottom_color, top_color, UV.y);
-    COLOR = col + vec4(vec3(rim), 0.0);
+    COLOR = col * (0.6 + 0.4 * shade) + vec4(vec3(rim), 0.0);
 }


### PR DESCRIPTION
## Summary
- fake 3D bulge lighting for SoftBodyFish
- compute body radius each frame and feed it to shader

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6868dffd6b44832993d162e743709c76