### PR TITLE
Add softbody fish normal shader

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -10,4 +10,5 @@
 - Softbody fish now uses twice as many points with lower spring strength for a smoother shape.
 - Updated softbody fish vertex coordinates for improved accuracy.
 - Softbody fish renderer uses precomputed triangulation to avoid runtime errors.
+- Softbody fish shader now generates fake normals for a rounded look.
 

--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -2,3 +2,9 @@
 
 Experimental soft body fish based on a spring-mesh approach.
 This folder contains a minimal Godot project for quick iteration.
+
+## Shading
+
+`shaders/soft_body_fish.gdshader` fakes 3‑D lighting by bulging the fish's UVs
+along custom X/Y radii. The center appears brighter while the edges fall off,
+giving the polygon a rounded body even as its vertices deform.

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
@@ -2,9 +2,18 @@ shader_type canvas_item;
 
 uniform vec4 top_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
 uniform vec4 bottom_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
+uniform vec2 body_radius = vec2(0.5, 1.0);
+uniform float bulge_power = 2.0;
+uniform vec3 light_dir = vec3(-0.3, -0.6, 1.0);
 
 void fragment() {
-    float rim = smoothstep(0.8, 1.0, 1.0 - length(UV * 2.0 - vec2(1.0)));
+    vec2 offset = (UV - vec2(0.5)) * 2.0;
+    vec2 norm = offset / body_radius;
+    float dist = length(norm);
+    float height = pow(max(0.0, 1.0 - dist), bulge_power);
+    vec3 normal = normalize(vec3(norm, height));
+    float light = clamp(dot(normal, normalize(light_dir)), 0.0, 1.0);
+    float rim = smoothstep(0.8, 1.0, 1.0 - dist);
     vec4 col = mix(bottom_color, top_color, UV.y);
-    COLOR = col + vec4(vec3(rim), 0.0);
+    COLOR = col * (0.6 + 0.4 * light) + vec4(vec3(rim), 0.0);
 }


### PR DESCRIPTION
## Summary
- implement fake normal shading in `soft_body_fish.gdshader`
- document shader usage in prototype README
- log new feature in CHANGE_LOG

## Testing
- `godot --headless --editor --import --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `godot --headless --check-only --quit --path BOIDFIsh/prototypes/softbody_fish --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet format --verify-no-changes --nologo --severity hidden` *(fails: Argument 'hidden' not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6868dffd6b44832993d162e743709c76