### PR TITLE
Add dynamic pillow normals to SoftBodyFish

### DIFF
--- a/BOIDFIsh/CHANGE_LOG.md
+++ b/BOIDFIsh/CHANGE_LOG.md
@@ -10,4 +10,5 @@
 - Softbody fish now uses twice as many points with lower spring strength for a smoother shape.
 - Updated softbody fish vertex coordinates for improved accuracy.
 - Softbody fish renderer uses precomputed triangulation to avoid runtime errors.
+- Softbody fish now uses dynamic pillow lighting from a viewport-generated heightmap.
 

--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -2,3 +2,5 @@
 
 Experimental soft body fish based on a spring-mesh approach.
 This folder contains a minimal Godot project for quick iteration.
+The fish silhouette is converted each frame into a blurred heightmap
+to generate dynamic pillow-style normals for lighting.

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/PillowNormal.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/PillowNormal.gd
@@ -1,0 +1,104 @@
+# gdlint:disable = class-variable-name,function-name,class-definitions-order
+###############################################################
+# BOIDFIsh/prototypes/softbody_fish/scripts/PillowNormal.gd
+# Key Classes      • PillowNormal – dynamic heightmap generator
+# Key Functions    • PN_update_points() – updates polygon data
+# Critical Consts  • PN_MARGIN_SH – padding around polygon
+# Editor Exports   • PN_texture_size_IN: Vector2i
+# Dependencies     • shaders/gaussian_blur.gdshader
+# Last Major Rev   • 24-05-01 – initial version
+###############################################################
+class_name PillowNormal
+extends Node2D
+
+const PN_MARGIN_SH: float = 2.0
+
+@export var PN_texture_size_IN: Vector2i = Vector2i(128, 64)
+
+var PN_heightmap_RD: Texture2D
+
+var _sil_vp: Viewport
+var _h_vp: Viewport
+var _v_vp: Viewport
+var _poly: Polygon2D
+var _h_mat: ShaderMaterial
+var _v_mat: ShaderMaterial
+var _h_rect: ColorRect
+var _v_rect: ColorRect
+
+
+func _ready() -> void:
+    _init_viewports()
+    PN_heightmap_RD = _v_vp.get_texture()
+
+
+func _init_viewports() -> void:
+    _sil_vp = _make_viewport()
+    _h_vp = _make_viewport()
+    _v_vp = _make_viewport()
+    add_child(_sil_vp)
+    add_child(_h_vp)
+    add_child(_v_vp)
+
+    _poly = Polygon2D.new()
+    _poly.color = Color.WHITE
+    _sil_vp.add_child(_poly)
+
+    _h_rect = _make_blur_rect(_sil_vp.get_texture(), Vector2(1.0, 0.0))
+    _h_vp.add_child(_h_rect)
+
+    _v_rect = _make_blur_rect(_h_vp.get_texture(), Vector2(0.0, 1.0))
+    _v_vp.add_child(_v_rect)
+
+
+func _make_viewport() -> SubViewport:
+    var vp: SubViewport = SubViewport.new()
+    vp.disable_3d = true
+    vp.transparent_bg = false
+    vp.render_target_clear_mode = SubViewport.CLEAR_MODE_ALWAYS
+    vp.render_target_update_mode = SubViewport.UPDATE_ALWAYS
+    vp.size = PN_texture_size_IN
+    return vp
+
+
+func _make_blur_rect(base_tex: Texture2D, dir: Vector2) -> ColorRect:
+    var rect: ColorRect = ColorRect.new()
+    rect.size = PN_texture_size_IN
+    rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    var mat: ShaderMaterial = ShaderMaterial.new()
+    mat.shader = load("res://shaders/gaussian_blur.gdshader")
+    mat.set_shader_parameter("base_texture", base_tex)
+    mat.set_shader_parameter("tex_size", Vector2(PN_texture_size_IN))
+    mat.set_shader_parameter("blur_direction", dir)
+    rect.material = mat
+    if dir.x > 0.0:
+        _h_mat = mat
+    else:
+        _v_mat = mat
+    return rect
+
+
+func PN_update_points(points: PackedVector2Array) -> void:
+    if points.is_empty():
+        return
+    var rect: Rect2 = Rect2(points[0], Vector2.ZERO)
+    for p in points:
+        rect = rect.expand(p)
+    rect = rect.grow(PN_MARGIN_SH)
+    var size: Vector2i = rect.size.ceil()
+    _sil_vp.size = size
+    _h_vp.size = size
+    _v_vp.size = size
+    _h_rect.size = size
+    _v_rect.size = size
+    _h_mat.set_shader_parameter("tex_size", Vector2(size))
+    _v_mat.set_shader_parameter("tex_size", Vector2(size))
+    var poly: PackedVector2Array = PackedVector2Array()
+    for p in points:
+        poly.append(p - rect.position)
+    _poly.polygon = poly
+    PN_heightmap_RD = _v_vp.get_texture()
+
+
+func PN_get_size() -> Vector2i:
+    return _v_vp.size

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/PillowNormal.gd.uid
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/PillowNormal.gd.uid
@@ -1,0 +1,1 @@
+uid://q3qaeaowghp

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd
@@ -12,6 +12,8 @@
 class_name SoftBodyFish
 extends Node2D
 
+const PillowNormal := preload("res://scripts/PillowNormal.gd")
+
 const FB_COORDS: Array[Vector2] = [
     Vector2(4.00, 5.50),
     Vector2(4.75, 6.05),
@@ -71,6 +73,7 @@ var FB_tail_ctrl_UP: Vector2 = Vector2.ZERO
 var FB_head_drag_UP: bool = false
 var FB_tail_drag_UP: bool = false
 var _mat: ShaderMaterial
+var FB_norm_gen_RD: PillowNormal
 
 # Pre-computed triangle indices.  Never empty unless initial triangulation failed.
 var _tri_indices: PackedInt32Array = PackedInt32Array()
@@ -82,6 +85,10 @@ func _ready() -> void:
     _mat = ShaderMaterial.new()
     _mat.shader = load("res://shaders/soft_body_fish.gdshader")
     material = _mat
+    FB_norm_gen_RD = PillowNormal.new()
+    add_child(FB_norm_gen_RD)
+    _mat.set_shader_parameter("heightmap", FB_norm_gen_RD.PN_heightmap_RD)
+    _mat.set_shader_parameter("heightmap_size", Vector2(FB_norm_gen_RD.PN_get_size()))
     _precompute_triangles()
     set_process_input(true)
 
@@ -127,6 +134,9 @@ func _process(delta: float) -> void:
     _physics_step(delta)
     FB_head_node_RD.position = FB_nodes_UP[FB_HEAD_IDX]
     FB_tail_node_RD.position = (FB_nodes_UP[FB_TAIL_IDXS[0]] + FB_nodes_UP[FB_TAIL_IDXS[1]]) * 0.5
+    FB_norm_gen_RD.PN_update_points(PackedVector2Array(FB_nodes_UP))
+    _mat.set_shader_parameter("heightmap", FB_norm_gen_RD.PN_heightmap_RD)
+    _mat.set_shader_parameter("heightmap_size", Vector2(FB_norm_gen_RD.PN_get_size()))
     queue_redraw()
 
 

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/gaussian_blur.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/gaussian_blur.gdshader
@@ -1,0 +1,15 @@
+shader_type canvas_item;
+
+uniform sampler2D base_texture : hint_default_black;
+uniform vec2 blur_direction = vec2(1.0, 0.0);
+uniform vec2 tex_size = vec2(64.0, 64.0);
+
+void fragment() {
+    vec2 texel = blur_direction / tex_size;
+    vec4 col = texture(base_texture, UV) * 0.227027;
+    col += texture(base_texture, UV + texel * 1.384615) * 0.316216;
+    col += texture(base_texture, UV - texel * 1.384615) * 0.316216;
+    col += texture(base_texture, UV + texel * 3.230769) * 0.070270;
+    col += texture(base_texture, UV - texel * 3.230769) * 0.070270;
+    COLOR = col;
+}

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/gaussian_blur.gdshader.uid
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/gaussian_blur.gdshader.uid
@@ -1,0 +1,1 @@
+uid://b6jwx7img5xaa

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/soft_body_fish.gdshader
@@ -3,8 +3,19 @@ shader_type canvas_item;
 uniform vec4 top_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
 uniform vec4 bottom_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
 
+uniform sampler2D heightmap : hint_default_black;
+uniform vec2 heightmap_size = vec2(64.0, 64.0);
+
 void fragment() {
+    vec2 texel = 1.0 / heightmap_size;
+    float c = texture(heightmap, UV).r;
+    float r = texture(heightmap, UV + vec2(texel.x, 0.0)).r;
+    float u = texture(heightmap, UV + vec2(0.0, texel.y)).r;
+    vec3 normal = normalize(vec3((c - r) * 2.0, (c - u) * 2.0, 1.0));
+    vec3 light_dir = normalize(vec3(-0.3, -0.5, 1.0));
+    float lit = clamp(dot(normal, light_dir), 0.0, 1.0);
     float rim = smoothstep(0.8, 1.0, 1.0 - length(UV * 2.0 - vec2(1.0)));
     vec4 col = mix(bottom_color, top_color, UV.y);
+    col.rgb *= mix(0.5, 1.2, lit);
     COLOR = col + vec4(vec3(rim), 0.0);
 }


### PR DESCRIPTION
## Summary
- generate a blurred heightmap each frame using `PillowNormal` helper
- sample the heightmap in `soft_body_fish.gdshader`
- connect the generator to `SoftBodyFish` for per‐frame updates
- include blur shader and update docs

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6868ed43296c83299f78eb766f856c3a