### PR TITLE
Add feathered stroke effect to softbody fish

### DIFF
--- a/BOIDFIsh/prototypes/softbody_fish/README.md
+++ b/BOIDFIsh/prototypes/softbody_fish/README.md
@@ -2,3 +2,10 @@
 
 Experimental soft body fish based on a spring-mesh approach.
 This folder contains a minimal Godot project for quick iteration.
+
+## Feathered Stroke Demo
+
+The scene now includes a dynamic distance-map generator that
+creates a feathered outline or concentric ring effect around the
+soft-body fish. Parameters such as `FB_stroke_width_IN` and
+`FB_ring_spacing_IN` can be tweaked from the inspector.

--- a/BOIDFIsh/prototypes/softbody_fish/scripts/DistanceMap.gd
+++ b/BOIDFIsh/prototypes/softbody_fish/scripts/DistanceMap.gd
@@ -1,0 +1,57 @@
+# gdlint:disable = class-variable-name,function-name
+# Helper node to capture the fish silhouette into a viewport and
+# produce a blurred distance map image for shader use.
+
+class_name DistanceMap
+extends Node
+
+@export var DM_viewport_size_IN: Vector2i = Vector2i(128, 128)
+@export var DM_blur_downscale_IN: int = 4
+
+var DM_viewport_RD: Viewport
+var DM_polygon_RD: Polygon2D
+var DM_distance_texture_RD: ImageTexture
+
+
+func _ready() -> void:
+    DM_viewport_RD = Viewport.new()
+    DM_viewport_RD.disable_3d = true
+    DM_viewport_RD.size = DM_viewport_size_IN
+    DM_viewport_RD.render_target_update_mode = Viewport.UPDATE_ALWAYS
+    DM_viewport_RD.render_target_v_flip = true
+    DM_viewport_RD.clear_color = Color.BLACK
+    add_child(DM_viewport_RD)
+    DM_viewport_RD.hide()
+
+    DM_polygon_RD = Polygon2D.new()
+    DM_polygon_RD.color = Color.WHITE
+    DM_viewport_RD.add_child(DM_polygon_RD)
+
+    DM_distance_texture_RD = ImageTexture.create_from_image(
+        Image.create(DM_viewport_size_IN.x, DM_viewport_size_IN.y, false, Image.FORMAT_RF)
+    )
+
+
+func update_polygon(points: PackedVector2Array) -> void:
+    var offset := Vector2(DM_viewport_size_IN) * 0.5
+    var pts := PackedVector2Array()
+    for p in points:
+        pts.append(p + offset)
+    DM_polygon_RD.polygon = pts
+    _update_distance_texture()
+
+
+func _update_distance_texture() -> void:
+    var img := DM_viewport_RD.get_texture().get_image()
+    var tmp := img.duplicate()
+    if DM_blur_downscale_IN > 1:
+        (
+            tmp
+            . resize(
+                DM_viewport_size_IN.x / DM_blur_downscale_IN,
+                DM_viewport_size_IN.y / DM_blur_downscale_IN,
+                Image.INTERPOLATE_BILINEAR,
+            )
+        )
+        tmp.resize(DM_viewport_size_IN.x, DM_viewport_size_IN.y, Image.INTERPOLATE_BILINEAR)
+    DM_distance_texture_RD.set_image(tmp)

--- a/BOIDFIsh/prototypes/softbody_fish/shaders/feathered_stroke.gdshader
+++ b/BOIDFIsh/prototypes/softbody_fish/shaders/feathered_stroke.gdshader
@@ -1,0 +1,19 @@
+shader_type canvas_item;
+
+uniform sampler2D distance_map : hint_white;
+uniform vec4 edge_color : source_color = vec4(0.2, 0.4, 0.6, 1.0);
+uniform vec4 center_color : source_color = vec4(0.8, 0.8, 0.9, 1.0);
+uniform float stroke_width : hint_range(0.01, 1.0) = 0.25;
+uniform float ring_spacing : hint_range(0.01, 1.0) = 0.0;
+uniform bool use_rings = false;
+
+void fragment() {
+    float d = texture(distance_map, UV).r;
+    float grad = smoothstep(0.0, stroke_width, d);
+    vec4 col = mix(edge_color, center_color, grad);
+    if (use_rings && ring_spacing > 0.0001) {
+        float ring = fract(d / ring_spacing);
+        col = mix(edge_color, center_color, ring);
+    }
+    COLOR = col;
+}


### PR DESCRIPTION
## Summary
- implement `DistanceMap` helper to capture the silhouette into a blurred viewport texture
- create `feathered_stroke.gdshader` for feathered outline or ring effects
- update `SoftBodyFish.gd` to generate a distance map every frame and expose shading parameters
- document the new feature in `README.md`

## Testing
- `pre-commit run --files BOIDFIsh/prototypes/softbody_fish/scripts/SoftBodyFish.gd BOIDFIsh/prototypes/softbody_fish/scripts/DistanceMap.gd BOIDFIsh/prototypes/softbody_fish/shaders/feathered_stroke.gdshader`

------
https://chatgpt.com/codex/tasks/task_e_6868f96573008329b4e4a5aa6290c0d5