### PR TITLE
Add quick roll bar

### DIFF
--- a/LIVEdie/main.tscn
+++ b/LIVEdie/main.tscn
@@ -1,7 +1,12 @@
 [gd_scene format=3 uid="uid://60wyaydkyepa"]
 
+[ext_resource type="PackedScene" path="res://scenes/QuickRollBar.tscn" id="1"]
+
 [node name="Main" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+
+[node name="QuickRollBar" parent="." instance=ExtResource(1)]
+

--- a/LIVEdie/scenes/QuickRollBar.tscn
+++ b/LIVEdie/scenes/QuickRollBar.tscn
@@ -1,0 +1,104 @@
+
+[gd_scene format=3 uid="uid://quickrollbar"]
+
+[ext_resource type="Script" path="res://scripts/quick_roll_bar.gd" id="1"]
+
+[node name="QuickRollBar" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="VBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 3
+
+[node name="StandardRow" type="HFlowContainer" parent="VBox"]
+anchor_right = 1.0
+size_flags_horizontal = 3
+
+[node name="ButtonD2" type="Button" parent="VBox/StandardRow"]
+text = "D2"
+
+[node name="ButtonD4" type="Button" parent="VBox/StandardRow"]
+text = "D4"
+
+[node name="ButtonD6" type="Button" parent="VBox/StandardRow"]
+text = "D6"
+
+[node name="ButtonD8" type="Button" parent="VBox/StandardRow"]
+text = "D8"
+
+[node name="ButtonD10" type="Button" parent="VBox/StandardRow"]
+text = "D10"
+
+[node name="ButtonD12" type="Button" parent="VBox/StandardRow"]
+text = "D12"
+
+[node name="ButtonD20" type="Button" parent="VBox/StandardRow"]
+text = "D20"
+
+[node name="ButtonD100" type="Button" parent="VBox/StandardRow"]
+text = "D%"
+
+[node name="ButtonToggleAdv" type="Button" parent="VBox/StandardRow"]
+text = "ADV"
+
+[node name="ButtonDX" type="Button" parent="VBox/StandardRow"]
+text = "DX?"
+
+[node name="ButtonRoll" type="Button" parent="VBox/StandardRow"]
+text = "ROLL"
+
+[node name="AdvancedRow" type="HFlowContainer" parent="VBox"]
+anchor_right = 1.0
+size_flags_horizontal = 3
+visible = false
+
+[node name="ButtonD13" type="Button" parent="VBox/AdvancedRow"]
+text = "D13"
+
+[node name="ButtonD16" type="Button" parent="VBox/AdvancedRow"]
+text = "D16"
+
+[node name="ButtonD24" type="Button" parent="VBox/AdvancedRow"]
+text = "D24"
+
+[node name="ButtonD30" type="Button" parent="VBox/AdvancedRow"]
+text = "D30"
+
+[node name="ButtonD60" type="Button" parent="VBox/AdvancedRow"]
+text = "D60"
+
+[node name="RepeatRow" type="HFlowContainer" parent="VBox"]
+anchor_right = 1.0
+size_flags_horizontal = 3
+
+[node name="ButtonX1" type="Button" parent="VBox/RepeatRow"]
+text = "x1"
+
+[node name="ButtonX2" type="Button" parent="VBox/RepeatRow"]
+text = "x2"
+
+[node name="ButtonX3" type="Button" parent="VBox/RepeatRow"]
+text = "x3"
+
+[node name="ButtonX4" type="Button" parent="VBox/RepeatRow"]
+text = "x4"
+
+[node name="ButtonX5" type="Button" parent="VBox/RepeatRow"]
+text = "x5"
+
+[node name="ButtonX10" type="Button" parent="VBox/RepeatRow"]
+text = "x10"
+
+[node name="QueueLabel" type="Label" parent="VBox"]
+text = "Queue:"
+size_flags_horizontal = 3
+
+[node name="ResultLabel" type="Label" parent="VBox"]
+text = "Result:"
+size_flags_horizontal = 3
+

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -1,0 +1,106 @@
+###############################################################
+# LIVEdie/scripts/quick_roll_bar.gd
+# Key Classes      • QuickRollBar – UI for standard/advanced dice
+# Key Functions    • _on_die_pressed() – queue dice
+#                   • _on_repeat_pressed() – update last die count
+# Critical Consts  • QR_SUPERSCRIPTS – superscript digits
+# Dependencies     • dice_parser.gd
+# Last Major Rev   • 24-04-XX – initial version
+###############################################################
+class_name QuickRollBar
+extends Control
+
+const QR_SUPERSCRIPTS := {
+    0: "\u2070",
+    1: "\u00b9",
+    2: "\u00b2",
+    3: "\u00b3",
+    4: "\u2074",
+    5: "\u2075",
+    6: "\u2076",
+    7: "\u2077",
+    8: "\u2078",
+    9: "\u2079"
+}
+
+var qr_queue: Array = []
+var qr_last_index := -1
+var qr_parser := DiceParser.new()
+
+@onready var qr_label_queue: Label = $VBox/QueueLabel
+@onready var qr_label_result: Label = $VBox/ResultLabel
+@onready var qr_advanced_row: Control = $VBox/AdvancedRow
+
+
+func _ready() -> void:
+    for b in $VBox/StandardRow.get_children():
+        if b is Button:
+            b.pressed.connect(_on_die_pressed.bind(b.text))
+    for b in $VBox/AdvancedRow.get_children():
+        if b is Button:
+            b.pressed.connect(_on_die_pressed.bind(b.text))
+    for b in $VBox/RepeatRow.get_children():
+        if b is Button:
+            b.pressed.connect(_on_repeat_pressed.bind(b.text))
+
+
+func _on_die_pressed(label: String) -> void:
+    if label == "ROLL":
+        _roll_dice()
+        return
+    if label == "\u25BC":
+        qr_advanced_row.visible = not qr_advanced_row.visible
+        return
+    var faces := 0
+    if label == "D%":
+        faces = 100
+    elif label.begins_with("DX"):
+        faces = 6
+    else:
+        faces = int(label.substr(1))
+    qr_queue.append({"faces": faces, "count": 1})
+    qr_last_index = qr_queue.size() - 1
+    _qr_update_queue_label()
+
+
+func _on_repeat_pressed(label: String) -> void:
+    if qr_last_index == -1:
+        return
+    var mult := int(label.substr(1))
+    qr_queue[qr_last_index]["count"] = mult
+    _qr_update_queue_label()
+
+
+func _qr_update_queue_label() -> void:
+    var parts := []
+    for entry in qr_queue:
+        var txt := "d" + str(entry["faces"])
+        if entry["count"] > 1:
+            txt += _qr_superscript(entry["count"])
+        parts.append(txt)
+    qr_label_queue.text = "Queue: " + " ".join(parts)
+
+
+func _qr_superscript(num: int) -> String:
+    var digits := []
+    var n := num
+    if n == 0:
+        return QR_SUPERSCRIPTS[0]
+    while n > 0:
+        digits.push_front(QR_SUPERSCRIPTS[n % 10])
+        n = int(n / 10)
+    return "".join(digits)
+
+
+func _roll_dice() -> void:
+    if qr_queue.is_empty():
+        return
+    var expr_parts := []
+    for entry in qr_queue:
+        expr_parts.append(str(entry["count"]) + "d" + str(entry["faces"]))
+    var expr := "+".join(expr_parts)
+    var result := qr_parser.evaluate(expr)
+    qr_label_result.text = "Result: " + str(result["total"])
+    qr_queue.clear()
+    qr_last_index = -1
+    _qr_update_queue_label()


### PR DESCRIPTION
## Summary
- add QuickRollBar scene with standard and advanced dice buttons
- implement repeater buttons and visual queue handling
- hook QuickRollBar into main.tscn

## Testing
- `gdlint LIVEdie/scripts/quick_roll_bar.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `cd LIVEdie && godot --headless -s res://tests/test_dice_parser.gd --quiet && cd ..`

------
https://chatgpt.com/codex/tasks/task_e_6869bc7a06c4832986f84cdf614b737f