### PR TITLE
Add QuickRollBar UI

### DIFF
--- a/LIVEdie/README.md
+++ b/LIVEdie/README.md
@@ -1,6 +1,8 @@
 # LIVEdie
 
-A minimal Godot 4 project prepared for mobile devices.
+A minimal Godot 4 project prepared for mobile devices. The current build
+includes a `QuickRollBar` scene with buttons for common dice and repeater
+controls.
 
 This folder contains the starting structure:
 

--- a/LIVEdie/main.tscn
+++ b/LIVEdie/main.tscn
@@ -1,7 +1,11 @@
 [gd_scene format=3 uid="uid://60wyaydkyepa"]
 
+[ext_resource type="PackedScene" path="res://scenes/QuickRollBar.tscn" id=1]
+
 [node name="Main" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+
+[node name="QuickRollBar" parent="Main" instance=ExtResource(1)]

--- a/LIVEdie/scenes/QuickRollBar.tscn
+++ b/LIVEdie/scenes/QuickRollBar.tscn
@@ -1,0 +1,28 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://scripts/quick_roll_bar.gd" id=1]
+
+[node name="QuickRollBar" type="VBoxContainer"]
+layout_mode = 3
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="StandardRow" type="HBoxContainer" parent="."]
+layout_mode = 3
+anchor_right = 1.0
+custom_constants/separation = 4
+
+[node name="AdvancedRow" type="HBoxContainer" parent="."]
+layout_mode = 3
+anchor_right = 1.0
+visible = false
+custom_constants/separation = 4
+
+[node name="RepeaterRow" type="HBoxContainer" parent="."]
+layout_mode = 3
+anchor_right = 1.0
+custom_constants/separation = 4
+
+[node name="QueueLabel" type="RichTextLabel" parent="."]
+fit_content = true

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -1,0 +1,128 @@
+#
+# LIVEdie/scripts/quick_roll_bar.gd
+# Key Classes      • QuickRollBar – UI for quick dice selection
+# Key Functions    • _on_die_pressed() – queue dice
+#                   • _on_repeat_pressed() – update last die count
+# Critical Consts  • QRB_STANDARD_FACES – default dice set
+# Dependencies     • none
+# Last Major Rev   • 24-04-XX – initial version
+###############################################################
+class_name QuickRollBar
+extends VBoxContainer
+
+const QRB_STANDARD_FACES := [2, 4, 6, 8, 10, 12, 20, 100]
+const QRB_ADVANCED_FACES := [13, 16, 24, 30, 60]
+const QRB_REPEAT_COUNTS := [1, 2, 3, 4, 5, 10]
+
+var qrb_queue := []
+var qrb_last_index := -1
+
+
+func _ready() -> void:
+    _qrb_create_dice_buttons()
+    _qrb_create_repeat_buttons()
+    _qrb_update_queue()
+
+
+func _qrb_create_dice_buttons() -> void:
+    var standard := $StandardRow
+    for f in QRB_STANDARD_FACES:
+        var b := Button.new()
+        var label := "D"
+        if f == 100:
+            label += "%"
+        else:
+            label += str(f)
+        b.text = label
+        b.pressed.connect(_on_die_pressed.bind(f))
+        b.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        standard.add_child(b)
+
+    var adv_toggle := Button.new()
+    adv_toggle.text = "\u25BC"  # down chevron
+    adv_toggle.pressed.connect(_on_toggle_advanced)
+    adv_toggle.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    standard.add_child(adv_toggle)
+
+    var roll := Button.new()
+    roll.text = "ROLL"
+    roll.pressed.connect(_on_roll)
+    roll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    standard.add_child(roll)
+
+    var advanced := $AdvancedRow
+    for f in QRB_ADVANCED_FACES:
+        var b2 := Button.new()
+        b2.text = "D" + str(f)
+        b2.pressed.connect(_on_die_pressed.bind(f))
+        b2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        advanced.add_child(b2)
+
+
+func _qrb_create_repeat_buttons() -> void:
+    var rep := $RepeaterRow
+    for n in QRB_REPEAT_COUNTS:
+        var b := Button.new()
+        b.text = "x" + str(n)
+        b.pressed.connect(_on_repeat_pressed.bind(n))
+        b.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        rep.add_child(b)
+
+
+func _on_toggle_advanced() -> void:
+    $AdvancedRow.visible = not $AdvancedRow.visible
+
+
+func _on_die_pressed(faces: int) -> void:
+    var entry := {"faces": faces, "count": 1}
+    qrb_queue.append(entry)
+    qrb_last_index = qrb_queue.size() - 1
+    _qrb_update_queue()
+
+
+func _on_repeat_pressed(mult: int) -> void:
+    if qrb_last_index >= 0 and qrb_last_index < qrb_queue.size():
+        qrb_queue[qrb_last_index]["count"] = mult
+        _qrb_update_queue()
+
+
+func _on_roll() -> void:
+    # Placeholder for integration with dice parser
+    pass
+
+
+func _qrb_update_queue() -> void:
+    var text := ""
+    for entry in qrb_queue:
+        var faces = entry["faces"]
+        var count = entry["count"]
+        var die_label := "d"
+        if faces == 100:
+            die_label += "%"
+        else:
+            die_label += str(faces)
+        text += die_label
+        if count > 1:
+            text += _qrb_superscript(count)
+        text += " "
+    $QueueLabel.text = text.strip_edges()
+
+
+func _qrb_superscript(num: int) -> String:
+    var digits := {
+        "0": "\u2070",
+        "1": "\u00B9",
+        "2": "\u00B2",
+        "3": "\u00B3",
+        "4": "\u2074",
+        "5": "\u2075",
+        "6": "\u2076",
+        "7": "\u2077",
+        "8": "\u2078",
+        "9": "\u2079",
+    }
+    var s := str(num)
+    var out := ""
+    for c in s:
+        out += digits.get(c, "")
+    return out


### PR DESCRIPTION
## Summary
- implement `QuickRollBar` scene containing buttons for common dice
- support toggled advanced dice row and repeat buttons
- show dice queue with superscript counts
- load QuickRollBar in `main.tscn`
- mention QuickRollBar in README

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6869bc7a06c4832986f84cdf614b737f