### PR TITLE
Add QuickRollBar UI

### DIFF
--- a/LIVEdie/main.tscn
+++ b/LIVEdie/main.tscn
@@ -1,7 +1,11 @@
-[gd_scene format=3 uid="uid://60wyaydkyepa"]
+[gd_scene load_steps=2 format=3 uid="uid://60wyaydkyepa"]
+
+[ext_resource type="PackedScene" path="res://scenes/quick_roll_bar.tscn" id="1"]
 
 [node name="Main" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+
+[node name="QuickRollBar" parent="." instance=ExtResource("1")]

--- a/LIVEdie/main.tscn
+++ b/LIVEdie/main.tscn
@@ -1,11 +1,21 @@
 [gd_scene load_steps=2 format=3 uid="uid://60wyaydkyepa"]
 
-[ext_resource type="PackedScene" path="res://scenes/quick_roll_bar.tscn" id="1"]
+[ext_resource type="PackedScene" uid="uid://qrollbar01" path="res://scenes/quick_roll_bar.tscn" id="1"]
 
 [node name="Main" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="QuickRollBar" parent="." instance=ExtResource("1")]
+layout_mode = 1
+offset_left = 28.0
+offset_top = 166.0
+offset_right = -736.0
+offset_bottom = -1661.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(3.225, 3.225)

--- a/LIVEdie/project.godot
+++ b/LIVEdie/project.godot
@@ -17,8 +17,12 @@ config/icon="res://icon.svg"
 
 [display]
 
-window/size/viewport_width=1280
-window/size/viewport_height=720
+window/size/viewport_width=1080
+window/size/viewport_height=1920
+window/size/mode=2
+window/size/initial_position_type=0
+window/stretch/mode="viewport"
+window/stretch/aspect="keep_width"
 window/handheld/orientation=1
 
 [dotnet]

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -1,0 +1,94 @@
+[gd_scene load_steps=3 format=3 uid="uid://qrollbar01"]
+
+[ext_resource type="Script" path="res://scripts/quick_roll_bar.gd" id="1"]
+
+[node name="QuickRollBar" type="VBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+layout_mode = 3
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1")
+
+[node name="StandardRow" type="HBoxContainer" parent="."]
+layout_mode = 3
+size_flags_horizontal = 3
+
+[node name="Die2" type="Button" parent="StandardRow"]
+text = "D2"
+
+[node name="Die4" type="Button" parent="StandardRow"]
+text = "D4"
+
+[node name="Die6" type="Button" parent="StandardRow"]
+text = "D6"
+
+[node name="Die8" type="Button" parent="StandardRow"]
+text = "D8"
+
+[node name="Die10" type="Button" parent="StandardRow"]
+text = "D10"
+
+[node name="Die12" type="Button" parent="StandardRow"]
+text = "D12"
+
+[node name="Die20" type="Button" parent="StandardRow"]
+text = "D20"
+
+[node name="Die100" type="Button" parent="StandardRow"]
+text = "D%"
+
+[node name="AdvancedToggle" type="Button" parent="StandardRow"]
+text = "v"
+
+[node name="DieX" type="Button" parent="StandardRow"]
+text = "DX?"
+
+[node name="RollButton" type="Button" parent="StandardRow"]
+text = "ROLL"
+
+[node name="AdvancedRow" type="HBoxContainer" parent="."]
+visible = false
+layout_mode = 3
+size_flags_horizontal = 3
+
+[node name="Die13" type="Button" parent="AdvancedRow"]
+text = "D13"
+
+[node name="Die16" type="Button" parent="AdvancedRow"]
+text = "D16"
+
+[node name="Die24" type="Button" parent="AdvancedRow"]
+text = "D24"
+
+[node name="Die30" type="Button" parent="AdvancedRow"]
+text = "D30"
+
+[node name="Die60" type="Button" parent="AdvancedRow"]
+text = "D60"
+
+[node name="RepeaterRow" type="HBoxContainer" parent="."]
+layout_mode = 3
+size_flags_horizontal = 3
+
+[node name="X1" type="Button" parent="RepeaterRow"]
+text = "x1"
+
+[node name="X2" type="Button" parent="RepeaterRow"]
+text = "x2"
+
+[node name="X3" type="Button" parent="RepeaterRow"]
+text = "x3"
+
+[node name="X4" type="Button" parent="RepeaterRow"]
+text = "x4"
+
+[node name="X5" type="Button" parent="RepeaterRow"]
+text = "x5"
+
+[node name="X10" type="Button" parent="RepeaterRow"]
+text = "x10"
+
+[node name="QueueLabel" type="Label" parent="."]
+text = ""
+

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -1,94 +1,115 @@
-[gd_scene load_steps=3 format=3 uid="uid://qrollbar01"]
+[gd_scene load_steps=2 format=3 uid="uid://qrollbar01"]
 
-[ext_resource type="Script" path="res://scripts/quick_roll_bar.gd" id="1"]
+[ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 
 [node name="QuickRollBar" type="VBoxContainer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-layout_mode = 3
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1")
 
 [node name="StandardRow" type="HBoxContainer" parent="."]
-layout_mode = 3
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Die2" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D2"
 
 [node name="Die4" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D4"
 
 [node name="Die6" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D6"
 
 [node name="Die8" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D8"
 
 [node name="Die10" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D10"
 
 [node name="Die12" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D12"
 
 [node name="Die20" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "D20"
 
-[node name="Die100" type="Button" parent="StandardRow"]
-text = "D%"
-
 [node name="AdvancedToggle" type="Button" parent="StandardRow"]
+layout_mode = 2
 text = "v"
 
-[node name="DieX" type="Button" parent="StandardRow"]
-text = "DX?"
-
-[node name="RollButton" type="Button" parent="StandardRow"]
-text = "ROLL"
+[node name="Die100" type="Button" parent="StandardRow"]
+layout_mode = 2
+text = "D%"
 
 [node name="AdvancedRow" type="HBoxContainer" parent="."]
 visible = false
-layout_mode = 3
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Die13" type="Button" parent="AdvancedRow"]
+layout_mode = 2
 text = "D13"
 
 [node name="Die16" type="Button" parent="AdvancedRow"]
+layout_mode = 2
 text = "D16"
 
 [node name="Die24" type="Button" parent="AdvancedRow"]
+layout_mode = 2
 text = "D24"
 
 [node name="Die30" type="Button" parent="AdvancedRow"]
+layout_mode = 2
 text = "D30"
 
 [node name="Die60" type="Button" parent="AdvancedRow"]
+layout_mode = 2
 text = "D60"
 
 [node name="RepeaterRow" type="HBoxContainer" parent="."]
-layout_mode = 3
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="X1" type="Button" parent="RepeaterRow"]
+layout_mode = 2
 text = "x1"
 
 [node name="X2" type="Button" parent="RepeaterRow"]
+layout_mode = 2
 text = "x2"
 
 [node name="X3" type="Button" parent="RepeaterRow"]
+layout_mode = 2
 text = "x3"
 
 [node name="X4" type="Button" parent="RepeaterRow"]
+layout_mode = 2
 text = "x4"
 
 [node name="X5" type="Button" parent="RepeaterRow"]
+layout_mode = 2
 text = "x5"
 
 [node name="X10" type="Button" parent="RepeaterRow"]
+layout_mode = 2
 text = "x10"
 
-[node name="QueueLabel" type="Label" parent="."]
-text = ""
+[node name="DieX" type="Button" parent="RepeaterRow"]
+layout_mode = 2
+text = "DX?"
 
+[node name="RollButton" type="Button" parent="RepeaterRow"]
+layout_mode = 2
+text = "ROLL"
+
+[node name="QueueLabel" type="Label" parent="."]
+layout_mode = 2

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -1,0 +1,113 @@
+###############################################################
+# LIVEdie/scripts/quick_roll_bar.gd
+# Key Classes      • QuickRollBar – UI for dice selection
+# Key Functions    • _on_die_pressed() – queue dice
+# Critical Consts  • QRB_SUPERSCRIPTS – digits for display
+# Dependencies     • DiceParser
+# Last Major Rev   • 24-04-XX – initial implementation
+###############################################################
+class_name QuickRollBar
+extends VBoxContainer
+
+const QRB_SUPERSCRIPTS := {
+    "0": "\u2070",
+    "1": "\u00B9",
+    "2": "\u00B2",
+    "3": "\u00B3",
+    "4": "\u2074",
+    "5": "\u2075",
+    "6": "\u2076",
+    "7": "\u2077",
+    "8": "\u2078",
+    "9": "\u2079"
+}
+
+var qrb_queue: Array = []
+var qrb_last_faces: int = 0
+
+
+func _ready() -> void:
+    _connect_dice_buttons($StandardRow)
+    _connect_dice_buttons($AdvancedRow)
+    $StandardRow/AdvancedToggle.pressed.connect(_on_toggle_advanced)
+    $StandardRow/RollButton.pressed.connect(_on_roll_pressed)
+    _connect_repeat_buttons()
+
+
+func _connect_dice_buttons(row: HBoxContainer) -> void:
+    for node in row.get_children():
+        if (
+            node is Button
+            and node.text.begins_with("D")
+            and node.text != "DX?"
+            and node.text != "ROLL"
+            and node != $StandardRow/AdvancedToggle
+        ):
+            var faces := int(node.text.substr(1).replace("%", "100"))
+            node.pressed.connect(_on_die_pressed.bind(faces))
+
+
+func _connect_repeat_buttons() -> void:
+    for node in $RepeaterRow.get_children():
+        if node is Button:
+            var mult := int(node.text.substr(1))
+            node.pressed.connect(_on_repeat_pressed.bind(mult))
+
+
+func _on_toggle_advanced() -> void:
+    $AdvancedRow.visible = not $AdvancedRow.visible
+
+
+func _on_die_pressed(faces: int) -> void:
+    _add_die(faces, 1)
+
+
+func _on_repeat_pressed(mult: int) -> void:
+    if qrb_last_faces == 0:
+        return
+    _add_die(qrb_last_faces, mult - 1)
+
+
+func _add_die(faces: int, qty: int) -> void:
+    if qrb_queue.is_empty() or qrb_queue[-1]["faces"] != faces:
+        qrb_queue.append({"faces": faces, "count": qty})
+    else:
+        qrb_queue[-1]["count"] += qty
+    qrb_last_faces = faces
+    _update_queue_label()
+
+
+func _update_queue_label() -> void:
+    var parts: Array = []
+    for entry in qrb_queue:
+        var part := "d" + str(entry["faces"])
+        if entry["count"] > 1:
+            part += _superscript(entry["count"])
+        parts.append(part)
+    $QueueLabel.text = " ".join(parts)
+
+
+func _superscript(val: int) -> String:
+    var result := ""
+    for c in str(val):
+        result += QRB_SUPERSCRIPTS.get(c, c)
+    return result
+
+
+func _build_expression() -> String:
+    var parts: Array = []
+    for entry in qrb_queue:
+        parts.append(str(entry["count"]) + "d" + str(entry["faces"]))
+    return " + ".join(parts)
+
+
+func _on_roll_pressed() -> void:
+    if qrb_queue.is_empty():
+        return
+    var parser := DiceParser.new()
+    var expr := _build_expression()
+    var res := parser.evaluate(expr)
+    print("Rolled: %s -> %s" % [expr, res])
+    qrb_queue.clear()
+    qrb_last_faces = 0
+    _update_queue_label()

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -30,7 +30,7 @@ func _ready() -> void:
     _connect_dice_buttons($StandardRow)
     _connect_dice_buttons($AdvancedRow)
     $StandardRow/AdvancedToggle.pressed.connect(_on_toggle_advanced)
-    $StandardRow/RollButton.pressed.connect(_on_roll_pressed)
+    $RepeaterRow/RollButton.pressed.connect(_on_roll_pressed)
     _connect_repeat_buttons()
 
 


### PR DESCRIPTION
## Summary
- create `QuickRollBar` scene and script with standard/advanced dice, repeater
- hook up scene in `main.tscn`
- show queued dice in superscript form

## Testing
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bc7a06c4832986f84cdf614b737f