### PR TITLE
Add long press features to QuickRollBar

### DIFF
--- a/LIVEdie/scenes/quantity_spinner.tscn
+++ b/LIVEdie/scenes/quantity_spinner.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3]
+
+[node name="QuantitySpinner" type="AcceptDialog"]
+visible = false
+popup_exclusive = true
+
+[node name="SpinBox" type="SpinBox" parent="."]
+min_value = 1
+max_value = 1000
+value = 1
+step = 1

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -22,8 +22,17 @@ const QRB_SUPERSCRIPTS := {
     "9": "\u2079"
 }
 
+const QRB_LONG_PRESS_TIME := 0.6
+
 var qrb_queue: Array = []
 var qrb_last_faces: int = 0
+var qrb_prev_queue: Array = []
+
+var qrb_long_timer: Timer
+var qrb_long_mode: String = ""
+var qrb_long_value: int = 0
+var qrb_long_active: bool = false
+var qrb_spinner: AcceptDialog
 
 
 func _ready() -> void:
@@ -32,6 +41,15 @@ func _ready() -> void:
     $StandardRow/AdvancedToggle.pressed.connect(_on_toggle_advanced)
     $RepeaterRow/RollButton.pressed.connect(_on_roll_pressed)
     _connect_repeat_buttons()
+    qrb_long_timer = Timer.new()
+    qrb_long_timer.one_shot = true
+    qrb_long_timer.wait_time = QRB_LONG_PRESS_TIME
+    add_child(qrb_long_timer)
+    qrb_long_timer.timeout.connect(_on_long_timeout)
+    qrb_spinner = load("res://scenes/quantity_spinner.tscn").instantiate()
+    add_child(qrb_spinner)
+    qrb_spinner.hide()
+    qrb_spinner.confirmed.connect(_on_spinner_confirmed)
 
 
 func _connect_dice_buttons(row: HBoxContainer) -> void:
@@ -45,6 +63,8 @@ func _connect_dice_buttons(row: HBoxContainer) -> void:
         ):
             var faces := int(node.text.substr(1).replace("%", "100"))
             node.pressed.connect(_on_die_pressed.bind(faces))
+            node.button_down.connect(_on_die_down.bind(node, faces))
+            node.button_up.connect(_on_die_up.bind(node, faces))
 
 
 func _connect_repeat_buttons() -> void:
@@ -52,10 +72,25 @@ func _connect_repeat_buttons() -> void:
         if node is Button:
             var mult := int(node.text.substr(1))
             node.pressed.connect(_on_repeat_pressed.bind(mult))
+            node.button_down.connect(_on_repeat_down.bind(node, mult))
+            node.button_up.connect(_on_repeat_up.bind(node, mult))
 
 
 func _on_toggle_advanced() -> void:
     $AdvancedRow.visible = not $AdvancedRow.visible
+
+
+func _on_die_down(_btn: Button, faces: int) -> void:
+    qrb_long_mode = "die"
+    qrb_long_value = faces
+    qrb_long_timer.start()
+
+
+func _on_die_up(_btn: Button, faces: int) -> void:
+    qrb_long_timer.stop()
+    if qrb_long_active:
+        return
+    _on_die_pressed(faces)
 
 
 func _on_die_pressed(faces: int) -> void:
@@ -66,6 +101,22 @@ func _on_repeat_pressed(mult: int) -> void:
     if qrb_last_faces == 0:
         return
     _add_die(qrb_last_faces, mult - 1)
+
+
+func _on_repeat_down(_btn: Button, mult: int) -> void:
+    qrb_long_mode = "repeat"
+    qrb_long_value = mult
+    qrb_long_timer.start()
+
+
+func _on_repeat_up(_btn: Button, mult: int) -> void:
+    qrb_long_timer.stop()
+    if qrb_long_active:
+        _apply_multiplier(mult)
+        qrb_long_active = false
+        _clear_preview()
+        return
+    _on_repeat_pressed(mult)
 
 
 func _add_die(faces: int, qty: int) -> void:
@@ -87,11 +138,53 @@ func _update_queue_label() -> void:
     $QueueLabel.text = " ".join(parts)
 
 
+func _preview_multiplier(mult: int) -> void:
+    var parts: Array = []
+    for entry in qrb_queue:
+        var part := "d" + str(entry["faces"])
+        var count: int = int(entry["count"]) * mult
+        if count > 1:
+            part += _superscript(count)
+        parts.append(part)
+    $QueueLabel.modulate = Color(1, 0.4, 0.4)
+    $QueueLabel.text = " ".join(parts)
+
+
+func _clear_preview() -> void:
+    $QueueLabel.modulate = Color.WHITE
+    _update_queue_label()
+
+
 func _superscript(val: int) -> String:
     var result := ""
     for c in str(val):
         result += QRB_SUPERSCRIPTS.get(c, c)
     return result
+
+
+func _apply_multiplier(mult: int) -> void:
+    if qrb_queue.is_empty():
+        return
+    qrb_prev_queue.clear()
+    for entry in qrb_queue:
+        qrb_prev_queue.append(entry.duplicate())
+        entry["count"] *= mult
+    _update_queue_label()
+
+
+func _on_long_timeout() -> void:
+    qrb_long_active = true
+    if qrb_long_mode == "repeat":
+        _preview_multiplier(qrb_long_value)
+    elif qrb_long_mode == "die":
+        qrb_spinner.get_node("SpinBox").value = 1
+        qrb_spinner.popup_centered()
+
+
+func _on_spinner_confirmed() -> void:
+    var qty := int(qrb_spinner.get_node("SpinBox").value)
+    _add_die(qrb_long_value, qty)
+    qrb_long_active = false
 
 
 func _build_expression() -> String:
@@ -110,4 +203,14 @@ func _on_roll_pressed() -> void:
     print("Rolled: %s -> %s" % [expr, res])
     qrb_queue.clear()
     qrb_last_faces = 0
+    _update_queue_label()
+
+
+func undo_last_action() -> void:
+    if qrb_prev_queue.is_empty():
+        return
+    qrb_queue = []
+    for entry in qrb_prev_queue:
+        qrb_queue.append(entry.duplicate())
+    qrb_prev_queue.clear()
     _update_queue_label()


### PR DESCRIPTION
## Summary
- implement long press multiplier logic in `QuickRollBar`
- add spinner popup for selecting quantity
- preview multiplier result before confirmation

## Testing
- `gdlint LIVEdie/scripts/quick_roll_bar.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: project assets missing)*
- `godot --headless --path LIVEdie --script tests/test_dice_parser.gd --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6869ed55e21c83299b97db52014848b0