### PR TITLE
Implement long-press dice multiplier

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -113,3 +113,18 @@ text = "ROLL"
 
 [node name="QueueLabel" type="Label" parent="."]
 layout_mode = 2
+
+[node name="PreviewDialog" type="AcceptDialog" parent="."]
+dialog_text = ""
+
+[node name="SpinnerDialog" type="AcceptDialog" parent="."]
+visible = false
+
+[node name="QuantitySpinBox" type="SpinBox" parent="SpinnerDialog"]
+min_value = 1.0
+step = 1.0
+value = 1.0
+
+[node name="LongPressTimer" type="Timer" parent="."]
+wait_time = 0.5
+one_shot = true


### PR DESCRIPTION
## Summary
- add dialog and timer nodes to `quick_roll_bar.tscn`
- implement long‑press detection and multiplier preview in `quick_roll_bar.gd`

## Testing
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ed55e21c83299b97db52014848b0