### PR TITLE
Add dial spinner input

### DIFF
--- a/LIVEdie/scenes/dial_spinner.tscn
+++ b/LIVEdie/scenes/dial_spinner.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/dial_spinner.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/dial_spinner_dial.gd" id="2"]
+
+[node name="DialSpinner" type="AcceptDialog"]
+visible = false
+script = ExtResource("1")
+
+[node name="DialArea" type="Control" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+script = ExtResource("2")
+
+[node name="ValueLabel" type="Label" parent="DialArea"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+align = 1
+valign = 1
+text = "1"
+
+[node name="InputPanel" type="PopupPanel" parent="DialArea"]
+visible = false
+
+

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://qrollbar01"]
+[gd_scene load_steps=3 format=3 uid="uid://qrollbar01"]
 
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/dial_spinner.tscn" id="2"]
 
 [node name="QuickRollBar" type="VBoxContainer"]
 anchors_preset = 15
@@ -117,13 +118,8 @@ layout_mode = 2
 [node name="PreviewDialog" type="AcceptDialog" parent="."]
 dialog_text = ""
 
-[node name="SpinnerDialog" type="AcceptDialog" parent="."]
+[node name="DialSpinner" parent="." instance=ExtResource("2")]
 visible = false
-
-[node name="QuantitySpinBox" type="SpinBox" parent="SpinnerDialog"]
-min_value = 1.0
-step = 1.0
-value = 1.0
 
 [node name="LongPressTimer" type="Timer" parent="."]
 wait_time = 0.5

--- a/LIVEdie/scripts/dial_spinner.gd
+++ b/LIVEdie/scripts/dial_spinner.gd
@@ -1,0 +1,142 @@
+#
+# LIVEdie/scripts/dial_spinner.gd
+# Key Classes      • DialSpinner – popup dial for quantity selection
+# Key Functions    • popup_centered() – show dial
+#                   • ds_value – current value
+# Critical Consts  • none
+# Dependencies     • none
+# Last Major Rev   • 24-06-XX – initial dial spinner
+###############################################################
+class_name DialSpinner
+extends AcceptDialog
+
+@export var ds_max_value: int = 1000
+@export var ds_accel_factor: float = 1.05
+
+var ds_value: int = 1
+var _dragging: bool = false
+var _last_angle: float = 0.0
+var _accel: float = 1.0
+var _flash: bool = false
+var _dial_angle: float = 0.0
+
+@onready var _dial := $DialArea
+@onready var _label: Label = $DialArea/ValueLabel
+@onready var _input_panel: PopupPanel = $DialArea/InputPanel as PopupPanel
+
+
+func _ready() -> void:
+    _label.text = str(ds_value)
+    _dial.gui_input.connect(_on_dial_input)
+    $DialArea/ValueLabel.gui_input.connect(_on_label_input)
+    _dial.spinner = self
+    _dial.queue_redraw()
+    _build_keypad()
+    _input_panel.hide()
+    self.hide()
+
+
+func _build_keypad() -> void:
+    var grid := GridContainer.new()
+    grid.columns = 3
+    _input_panel.add_child(grid)
+    var order := ["7", "8", "9", "4", "5", "6", "1", "2", "3", "DEL", "0", "OK"]
+    for key in order:
+        var btn := Button.new()
+        if key == "DEL":
+            btn.text = "<x"
+        else:
+            btn.text = key
+        grid.add_child(btn)
+        if key.is_valid_int():
+            btn.pressed.connect(_on_key.bind(key))
+        elif key == "OK":
+            btn.pressed.connect(_on_ok_pressed)
+        else:
+            btn.pressed.connect(_on_del_pressed)
+
+
+func _on_label_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.pressed:
+        _input_panel.popup_centered()
+        event.accept()
+
+
+func _on_key(ch: String) -> void:
+    var s := str(ds_value)
+    if s == "0":
+        s = ""
+    s += ch
+    var v: int = clamp(int(s), 0, ds_max_value)
+    ds_value = v
+    _update_label()
+
+
+func _on_ok_pressed() -> void:
+    _input_panel.hide()
+
+
+func _on_del_pressed() -> void:
+    var s := str(ds_value)
+    if s.length() > 1:
+        s = s.substr(0, s.length() - 1)
+    else:
+        s = "0"
+    ds_value = int(s)
+    _update_label()
+
+
+func _on_dial_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton:
+        if event.pressed:
+            _dragging = true
+            _last_angle = _pos_angle(event.position)
+            _accel = 1.0
+        else:
+            _dragging = false
+    elif event is InputEventMouseMotion and _dragging:
+        var angle := _pos_angle(event.position)
+        var delta := angle - _last_angle
+        delta = wrapf(delta, -PI, PI)
+        _last_angle = angle
+        var step := int(delta * 30.0 * _accel)
+        if step != 0:
+            _set_value(ds_value + step)
+            _accel *= ds_accel_factor
+
+
+func _pos_angle(pos: Vector2) -> float:
+    var center: Vector2 = _dial.size / 2
+    return atan2(pos.y - center.y, pos.x - center.x)
+
+
+func _set_value(v: int) -> void:
+    var new_val: int = clamp(v, 0, ds_max_value)
+    if new_val == ds_value:
+        return
+    var diff: int = new_val - ds_value
+    ds_value = new_val
+    _flash = not _flash
+    _dial_angle += diff * 0.05
+    _update_label()
+    _pulse()
+    _dial.queue_redraw()
+
+
+func _update_label() -> void:
+    _label.text = str(ds_value)
+
+
+func _pulse() -> void:
+    _label.scale = Vector2.ONE
+    var tw := create_tween()
+    tw.tween_property(_label, "scale", Vector2(1.2, 1.2), 0.1)
+    tw.tween_property(_label, "scale", Vector2.ONE, 0.2).set_delay(0.1)
+
+
+func open_dial(size: Vector2i = Vector2i()) -> void:
+    _update_label()
+    _input_panel.hide()
+    _flash = false
+    _dial.queue_redraw()
+    popup_centered(size)

--- a/LIVEdie/scripts/dial_spinner_dial.gd
+++ b/LIVEdie/scripts/dial_spinner_dial.gd
@@ -1,0 +1,19 @@
+extends Control
+
+var spinner: DialSpinner
+
+
+func _draw() -> void:
+    if spinner == null:
+        return
+    var center: Vector2 = size / 2
+    var radius: float = min(size.x, size.y) / 2 - 10
+    var segs := 12
+    var seg_angle := TAU / segs
+    for i in range(segs):
+        var c: Color = (
+            Color(0.4, 0.6, 1.0) if (i + int(spinner._flash)) % 2 == 0 else Color(0.6, 0.4, 1.0)
+        )
+        var a0 := seg_angle * i + spinner._dial_angle
+        var a1 := a0 + seg_angle
+        draw_arc(center, radius, a0, a1, segs, c, 8)

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -39,7 +39,7 @@ func _ready() -> void:
     _connect_repeat_buttons()
     $LongPressTimer.timeout.connect(_on_long_press_timeout)
     $PreviewDialog.confirmed.connect(_on_preview_confirmed)
-    $SpinnerDialog.confirmed.connect(_on_spinner_confirmed)
+    $DialSpinner.confirmed.connect(_on_spinner_confirmed)
 
 
 func _connect_dice_buttons(row: HBoxContainer) -> void:
@@ -180,12 +180,12 @@ func _apply_multiplier(mult: int) -> void:
 
 func _show_spinner(faces: int) -> void:
     qrb_long_press_param = faces
-    $SpinnerDialog/QuantitySpinBox.value = 1
-    $SpinnerDialog.popup_centered()
+    $DialSpinner.ds_value = 1
+    $DialSpinner.open_dial()
 
 
 func _on_spinner_confirmed() -> void:
-    var qty := int($SpinnerDialog/QuantitySpinBox.value)
+    var qty := int($DialSpinner.ds_value)
     _add_die(qrb_long_press_param, qty)
 
 


### PR DESCRIPTION
## Summary
- implement new dial-style spinner with acceleration
- auto-build keypad for dial entry
- wire dial into quick roll bar scene

## Testing
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project)*

------
https://chatgpt.com/codex/tasks/task_e_686a0660de388329ae9b2903fb560847