### PR TITLE
Add roll history drawer and queue chips

### DIFF
--- a/LIVEdie/main.tscn
+++ b/LIVEdie/main.tscn
@@ -14,6 +14,3 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="QuickRollBar" parent="." instance=ExtResource("1")]
-custom_minimum_size = Vector2(1080, 125)
-layout_mode = 1
-offset_bottom = -1778.0

--- a/LIVEdie/scenes/dial_spinner.tscn
+++ b/LIVEdie/scenes/dial_spinner.tscn
@@ -14,8 +14,10 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -100.0
-offset_bottom = -100.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 1
@@ -35,4 +37,5 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="InputPanel" type="PopupPanel" parent="DialArea"]
+size = Vector2i(400, 400)
 visible = true

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://qrollbar01"]
+[gd_scene load_steps=4 format=3 uid="uid://qrollbar01"]
 
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://c4jfdeyqiow6v" path="res://scenes/dial_spinner.tscn" id="2"]
-[ext_resource type="PackedScene" uid="uid://rollhistory01" path="res://scenes/roll_history_panel.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://rollhist01" path="res://scenes/roll_history_panel.tscn" id="3"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -13,13 +13,11 @@ offset_bottom = 293.0
 grow_horizontal = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 25
-alignment = 1
 script = ExtResource("1")
 
 [node name="StandardRow" type="HBoxContainer" parent="QuickRollBar"]
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
-size_flags_vertical = 3
 theme_override_constants/separation = 30
 alignment = 1
 
@@ -128,6 +126,7 @@ theme_override_font_sizes/font_size = 35
 text = "D50"
 
 [node name="Die60" type="Button" parent="QuickRollBar/AdvancedRow"]
+visible = false
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
@@ -203,33 +202,32 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 35
 text = "⌫"
 
-
 [node name="QueueRow" type="PanelContainer" parent="QuickRollBar"]
+custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
-theme_override_constants/margin_left = 8
-theme_override_constants/margin_right = 8
-theme_override_constants/margin_top = 4
-theme_override_constants/margin_bottom = 4
 
 [node name="HScroll" type="ScrollContainer" parent="QuickRollBar/QueueRow"]
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="DiceChips" type="HBoxContainer" parent="QuickRollBar/QueueRow/HScroll"]
+layout_mode = 2
 theme_override_constants/separation = 4
 
 [node name="PreviewDialog" type="AcceptDialog" parent="QuickRollBar"]
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
 
+[node name="RollHistoryPanel" parent="." instance=ExtResource("3")]
+custom_minimum_size = Vector2(0, 400)
+offset_top = -400.0
 
 [node name="HistoryButton" type="Button" parent="."]
-layout_mode = 0
-anchors_preset = 10
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -80.0
-offset_bottom = 340.0
+offset_top = 968.0
+offset_bottom = -1.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "History"
-
-
-[node name="RollHistoryPanel" parent="." instance=ExtResource("3")]

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://c4jfdeyqiow6v" path="res://scenes/dial_spinner.tscn" id="2"]
+[ext_resource type="PackedScene" uid="uid://rollhistory01" path="res://scenes/roll_history_panel.tscn" id="3"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -202,17 +203,33 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 35
 text = "⌫"
 
-[node name="QueueLabel" type="Label" parent="QuickRollBar"]
+
+[node name="QueueRow" type="PanelContainer" parent="QuickRollBar"]
 layout_mode = 2
-theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 15
-theme_override_constants/shadow_outline_size = 15
-theme_override_font_sizes/font_size = 60
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="HScroll" type="ScrollContainer" parent="QuickRollBar/QueueRow"]
+size_flags_horizontal = 3
+
+[node name="DiceChips" type="HBoxContainer" parent="QuickRollBar/QueueRow/HScroll"]
+theme_override_constants/separation = 4
 
 [node name="PreviewDialog" type="AcceptDialog" parent="QuickRollBar"]
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
 
-[node name="LongPressTimer" type="Timer" parent="QuickRollBar"]
-wait_time = 0.5
-one_shot = true
+
+[node name="HistoryButton" type="Button" parent="."]
+layout_mode = 0
+anchors_preset = 10
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -80.0
+offset_bottom = 340.0
+text = "History"
+
+
+[node name="RollHistoryPanel" parent="." instance=ExtResource("3")]

--- a/LIVEdie/scenes/roll_history_panel.tscn
+++ b/LIVEdie/scenes/roll_history_panel.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=3 format=3 uid="uid://rollhistory01"]
+
+[ext_resource type="Script" uid="uid://rollhistorygd" path="res://scripts/roll_history_panel.gd" id="1"]
+
+[node name="RollHistoryPanel" type="PanelContainer"]
+anchors_preset = 8
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -400.0
+visible = false
+script = ExtResource("1")
+
+[node name="HeaderBar" type="HBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Title" type="Label" parent="HeaderBar"]
+text = "Roll History"
+
+[node name="Spacer" type="Control" parent="HeaderBar"]
+size_flags_horizontal = 3
+
+[node name="Close" type="Button" parent="HeaderBar"]
+text = "✖"
+
+[node name="Scroll" type="ScrollContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 40.0
+
+[node name="Entries" type="VBoxContainer" parent="Scroll"]
+size_flags_vertical = 3

--- a/LIVEdie/scenes/roll_history_panel.tscn
+++ b/LIVEdie/scenes/roll_history_panel.tscn
@@ -1,15 +1,17 @@
-[gd_scene load_steps=3 format=3 uid="uid://rollhistory01"]
+[gd_scene load_steps=2 format=3 uid="uid://rollhist01"]
 
-[ext_resource type="Script" uid="uid://rollhistorygd" path="res://scripts/roll_history_panel.gd" id="1"]
+[ext_resource type="Script" uid="uid://c0q3ieejan2mr" path="res://scripts/roll_history_panel.gd" id="1"]
 
 [node name="RollHistoryPanel" type="PanelContainer"]
-anchors_preset = 8
-anchor_left = 0.0
-anchor_right = 1.0
+anchors_preset = 12
 anchor_top = 1.0
+anchor_right = 1.0
 anchor_bottom = 1.0
-offset_top = -400.0
-visible = false
+offset_top = -500.0
+grow_horizontal = 2
+grow_vertical = 0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1")
 
 [node name="HeaderBar" type="HBoxContainer" parent="."]
@@ -17,19 +19,20 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Title" type="Label" parent="HeaderBar"]
+layout_mode = 2
 text = "Roll History"
 
 [node name="Spacer" type="Control" parent="HeaderBar"]
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Close" type="Button" parent="HeaderBar"]
+layout_mode = 2
 text = "✖"
 
 [node name="Scroll" type="ScrollContainer" parent="."]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_top = 40.0
+layout_mode = 2
 
 [node name="Entries" type="VBoxContainer" parent="Scroll"]
+layout_mode = 2
 size_flags_vertical = 3

--- a/LIVEdie/scripts/dial_spinner.gd
+++ b/LIVEdie/scripts/dial_spinner.gd
@@ -44,9 +44,13 @@ func _build_keypad() -> void:
     for key in order:
         var btn := Button.new()
         if key == "DEL":
-            btn.text = "<x"
+            btn.text = "\u232b"
+        elif key == "OK":
+            btn.text = "\u2714"
         else:
             btn.text = key
+        btn.custom_minimum_size = Vector2(80, 80)
+        btn.add_theme_font_size_override("font_size", 32)
         grid.add_child(btn)
         if key.is_valid_int():
             btn.pressed.connect(_on_key.bind(key))

--- a/LIVEdie/scripts/roll_history_panel.gd
+++ b/LIVEdie/scripts/roll_history_panel.gd
@@ -1,0 +1,28 @@
+###############################################################
+# LIVEdie/scripts/roll_history_panel.gd
+# Key Classes      • RollHistoryPanel – slide-up drawer for rolls
+# Key Functions    • add_entry() – append log entry
+#                   show_panel() – open drawer
+#                   hide_panel() – close drawer
+# Dependencies     • none
+# Last Major Rev   • 24-06-XX – initial implementation
+###############################################################
+class_name RollHistoryPanel
+extends PanelContainer
+
+@onready var _entries: VBoxContainer = $Scroll/Entries
+
+
+func add_entry(text: String) -> void:
+    var label := Label.new()
+    label.text = text
+    label.custom_minimum_size.y = 48
+    _entries.add_child(label)
+
+
+func show_panel() -> void:
+    show()
+
+
+func hide_panel() -> void:
+    hide()


### PR DESCRIPTION
## Summary
- enhance dial spinner keypad visuals
- display dice queue as scrolling chips and hide when empty
- add roll history drawer panel with toggle button
- show roll results in history list

## Testing
- `gdlint LIVEdie/scripts/dial_spinner.gd LIVEdie/scripts/quick_roll_bar.gd LIVEdie/scripts/roll_history_panel.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_686aac2ecee883299f351f5587a3cf67