### PR TITLE
Fix long-press spinner and repeat buttons

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -218,6 +218,10 @@ theme_override_constants/separation = 4
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
 
+[node name="LongPressTimer" type="Timer" parent="QuickRollBar"]
+wait_time = 0.5
+one_shot = true
+
 [node name="RollHistoryPanel" parent="." instance=ExtResource("3")]
 custom_minimum_size = Vector2(0, 400)
 offset_top = -400.0

--- a/LIVEdie/scripts/dial_spinner.gd
+++ b/LIVEdie/scripts/dial_spinner.gd
@@ -138,9 +138,13 @@ func _pulse() -> void:
     tw.tween_property(_label, "scale", Vector2.ONE, 0.2).set_delay(0.1)
 
 
-func open_dial(size: Vector2i = Vector2i()) -> void:
+func open_dial(size: Vector2i = Vector2i(), pos: Vector2 = Vector2.INF) -> void:
     _update_label()
     _input_panel.hide()
     _flash = false
     _dial.queue_redraw()
-    popup_centered(size)
+    if pos.is_finite():
+        var rect := Rect2i(pos, size if size != Vector2i() else get_size())
+        popup(rect)
+    else:
+        popup_centered(size)


### PR DESCRIPTION
## Summary
- restore `LongPressTimer` and long-press logic
- allow positioning for `DialSpinner` and pop it over pressed die
- fix repeat button logic to add full multiplier except for single die

## Testing
- `gdlint $(git diff --name-only --cached -- '*.gd')`
- `dotnet format --verify-no-changes --nologo --severity hidden` *(fails: Argument 'hidden' not recognized)*
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene defined)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686ad088969c8329a062d12bec3f5545