### PR TITLE
Fix spinner long press and repeat counts

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -218,6 +218,10 @@ theme_override_constants/separation = 4
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
 
+[node name="LongPressTimer" type="Timer" parent="QuickRollBar"]
+wait_time = 0.5
+one_shot = true
+
 [node name="RollHistoryPanel" parent="." instance=ExtResource("3")]
 custom_minimum_size = Vector2(0, 400)
 offset_top = -400.0

--- a/LIVEdie/scripts/dial_spinner.gd
+++ b/LIVEdie/scripts/dial_spinner.gd
@@ -144,3 +144,12 @@ func open_dial(size: Vector2i = Vector2i()) -> void:
     _flash = false
     _dial.queue_redraw()
     popup_centered(size)
+
+
+func open_dial_at(center: Vector2, size: Vector2i = Vector2i()) -> void:
+    _update_label()
+    _input_panel.hide()
+    _flash = false
+    _dial.queue_redraw()
+    position = center - Vector2(size if size != Vector2i() else self.size) / 2
+    popup()


### PR DESCRIPTION
## Summary
- restore long-press handling via hidden timer
- center DialSpinner over the pressed die
- fix repeat buttons to always add full amount

## Testing
- `gdlint LIVEdie/scripts/dial_spinner.gd LIVEdie/scripts/quick_roll_bar.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad088969c8329a062d12bec3f5545