### PR TITLE
Implement instant dial spinner

### DIFF
--- a/LIVEdie/scenes/dial_spinner.tscn
+++ b/LIVEdie/scenes/dial_spinner.tscn
@@ -3,10 +3,9 @@
 [ext_resource type="Script" uid="uid://dbsphx70nw45d" path="res://scripts/dial_spinner.gd" id="1"]
 [ext_resource type="Script" uid="uid://c8wakp5hy3oqe" path="res://scripts/dial_spinner_dial.gd" id="2"]
 
-[node name="DialSpinner" type="AcceptDialog"]
-title = "Dail a value"
+[node name="DialSpinner" type="Control"]
+visible = false
 size = Vector2i(400, 400)
-max_size = Vector2i(400, 400)
 script = ExtResource("1")
 
 [node name="DialArea" type="Control" parent="."]

--- a/LIVEdie/scripts/dial_spinner.gd
+++ b/LIVEdie/scripts/dial_spinner.gd
@@ -1,14 +1,16 @@
 #
 # LIVEdie/scripts/dial_spinner.gd
-# Key Classes      • DialSpinner – popup dial for quantity selection
-# Key Functions    • popup_centered() – show dial
+# Key Classes      • DialSpinner – overlay dial for quantity selection
+# Key Functions    • open_dial() / open_dial_at() – show dial
 #                   • ds_value – current value
 # Critical Consts  • none
 # Dependencies     • none
 # Last Major Rev   • 24-06-XX – initial dial spinner
 ###############################################################
 class_name DialSpinner
-extends AcceptDialog
+extends Control
+
+signal value_selected(value: int)
 
 @export var ds_max_value: int = 1000
 @export var ds_accel_factor: float = 1.05
@@ -98,6 +100,7 @@ func _on_dial_input(event: InputEvent) -> void:
             _accel = 1.0
         else:
             _dragging = false
+            _finalize()
     elif event is InputEventMouseMotion and _dragging:
         var angle := _pos_angle(event.position)
         var delta := angle - _last_angle
@@ -143,7 +146,10 @@ func open_dial(size: Vector2i = Vector2i()) -> void:
     _input_panel.hide()
     _flash = false
     _dial.queue_redraw()
-    popup_centered(size)
+    if size != Vector2i():
+        custom_minimum_size = size
+    position = Vector2.ZERO
+    show()
 
 
 func open_dial_at(center: Vector2, size: Vector2i = Vector2i()) -> void:
@@ -151,5 +157,12 @@ func open_dial_at(center: Vector2, size: Vector2i = Vector2i()) -> void:
     _input_panel.hide()
     _flash = false
     _dial.queue_redraw()
+    if size != Vector2i():
+        custom_minimum_size = size
     position = center - Vector2(size if size != Vector2i() else self.size) / 2
-    popup()
+    show()
+
+
+func _finalize() -> void:
+    emit_signal("value_selected", ds_value)
+    hide()

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -44,7 +44,7 @@ func _ready() -> void:
     _connect_repeat_buttons()
     $LongPressTimer.timeout.connect(_on_long_press_timeout)
     $PreviewDialog.confirmed.connect(_on_preview_confirmed)
-    $DialSpinner.confirmed.connect(_on_spinner_confirmed)
+    $DialSpinner.value_selected.connect(_on_spinner_selected)
     qrb_history_button.pressed.connect(_on_history_pressed)
 
 
@@ -208,9 +208,8 @@ func _show_spinner(faces: int) -> void:
     $DialSpinner.open_dial_at(center)
 
 
-func _on_spinner_confirmed() -> void:
-    var qty := int($DialSpinner.ds_value)
-    _add_die(qrb_long_press_param, qty)
+func _on_spinner_selected(value: int) -> void:
+    _add_die(qrb_long_press_param, value)
 
 
 func _on_history_pressed() -> void:


### PR DESCRIPTION
## Summary
- enable gesture-based quantity selection
- finalize spinner on pointer release
- wire QuickRollBar to new `value_selected` signal
- update dial spinner scene for non-modal overlay

## Testing
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build ./BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686af24079b883298dd2e7af924737c6