### PR TITLE
Implement release-driven spinner confirm

### DIFF
--- a/LIVEdie/scripts/dial_spinner.gd
+++ b/LIVEdie/scripts/dial_spinner.gd
@@ -31,9 +31,16 @@ func _ready() -> void:
     $DialArea/ValueLabel.gui_input.connect(_on_label_input)
     _dial.spinner = self
     _dial.queue_redraw()
+    get_ok_button().hide()
+    exclusive = false
     _build_keypad()
     _input_panel.hide()
     self.hide()
+
+
+func _confirm() -> void:
+    hide()
+    emit_signal("confirmed")
 
 
 func _build_keypad() -> void:
@@ -91,14 +98,15 @@ func _on_del_pressed() -> void:
 
 
 func _on_dial_input(event: InputEvent) -> void:
-    if event is InputEventMouseButton:
+    if event is InputEventMouseButton or event is InputEventScreenTouch:
         if event.pressed:
             _dragging = true
             _last_angle = _pos_angle(event.position)
             _accel = 1.0
         else:
             _dragging = false
-    elif event is InputEventMouseMotion and _dragging:
+            _confirm()
+    elif (event is InputEventMouseMotion or event is InputEventScreenDrag) and _dragging:
         var angle := _pos_angle(event.position)
         var delta := angle - _last_angle
         delta = wrapf(delta, -PI, PI)


### PR DESCRIPTION
## Summary
- make the dial spinner non-modal
- auto-confirm spinner value on pointer release

## Testing
- `gdlint $(git diff --name-only --cached -- '*.gd')`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: assets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af24079b883298dd2e7af924737c6