### PR TITLE
Add custom die input & delete on quick roll bar

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://c4jfdeyqiow6v" path="res://scenes/dial_spinner.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://rollhist01" path="res://scenes/roll_history_panel.tscn" id="3"]
+[ext_resource type="Script" uid="uid://customdie01" path="res://scripts/custom_die_dialog.gd" id="4"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -214,6 +215,9 @@ layout_mode = 2
 theme_override_constants/separation = 4
 
 [node name="PreviewDialog" type="AcceptDialog" parent="QuickRollBar"]
+
+[node name="CustomDieDialog" type="AcceptDialog" parent="QuickRollBar"]
+script = ExtResource("4")
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
 

--- a/LIVEdie/scripts/custom_die_dialog.gd
+++ b/LIVEdie/scripts/custom_die_dialog.gd
@@ -1,0 +1,96 @@
+###############################################################
+# LIVEdie/scripts/custom_die_dialog.gd
+# Key Classes      • CustomDieDialog – keypad popup for die sides
+# Key Functions    • popup_with_value() – open dialog with default
+# Dependencies     • none
+# Last Major Rev   • 24-06-XX – initial implementation
+###############################################################
+class_name CustomDieDialog
+extends AcceptDialog
+
+signal sides_entered(sides: int)
+
+var cd_value: int = 6
+var _replace: bool = true
+var _ok_selected: bool = false
+var _label: Label
+var _grid: GridContainer
+
+
+func _ready() -> void:
+    title = "Custom Die"
+    _label = Label.new()
+    _label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    _label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+    _label.custom_minimum_size = Vector2(200, 60)
+    add_child(_label)
+    _grid = GridContainer.new()
+    _grid.columns = 3
+    add_child(_grid)
+    _build_buttons()
+    get_ok_button().hide()
+    connect("visibility_changed", _on_visibility_changed)
+
+
+func _build_buttons() -> void:
+    var order := ["7", "8", "9", "4", "5", "6", "1", "2", "3", "DEL", "0", "OK"]
+    for key in order:
+        var btn := Button.new()
+        btn.custom_minimum_size = Vector2(80, 80)
+        btn.add_theme_font_size_override("font_size", 32)
+        if key == "DEL":
+            btn.text = "\u232b"
+            btn.pressed.connect(_on_del_pressed)
+        elif key == "OK":
+            btn.text = "\u2714"
+            btn.pressed.connect(_on_ok_pressed)
+        else:
+            btn.text = key
+            btn.pressed.connect(_on_digit_pressed.bind(key))
+        _grid.add_child(btn)
+
+
+func popup_with_value(value: int) -> void:
+    cd_value = value
+    _label.text = str(value)
+    _replace = true
+    _ok_selected = false
+    popup_centered()
+
+
+func _on_digit_pressed(digit: String) -> void:
+    if _replace:
+        _label.text = digit
+        _replace = false
+    else:
+        var s := _label.text
+        if s == "0":
+            s = ""
+        _label.text = s + digit
+    cd_value = int(_label.text)
+
+
+func _on_del_pressed() -> void:
+    if _label.text == "0":
+        _ok_selected = true
+        hide()
+        emit_signal("sides_entered", 0)
+        return
+    var s := _label.text
+    if s.length() > 1:
+        s = s.substr(0, s.length() - 1)
+    else:
+        s = "0"
+    _label.text = s
+    cd_value = int(s)
+
+
+func _on_ok_pressed() -> void:
+    _ok_selected = true
+    hide()
+    emit_signal("sides_entered", cd_value)
+
+
+func _on_visibility_changed() -> void:
+    if not _ok_selected:
+        emit_signal("sides_entered", 0)

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -34,6 +34,9 @@ var qrb_long_press_button: Control
 @onready var qrb_chip_box: HBoxContainer = $QueueRow/HScroll/DiceChips
 @onready var qrb_history_button: Button = $"../HistoryButton"
 @onready var qrb_history_panel: RollHistoryPanel = $"../RollHistoryPanel"
+@onready var qrb_del_button: Button = $RepeaterRow/DieX2
+@onready var qrb_custom_button: Button = $RepeaterRow/DieX
+@onready var qrb_custom_dialog: CustomDieDialog = $CustomDieDialog
 
 
 func _ready() -> void:
@@ -46,6 +49,9 @@ func _ready() -> void:
     $PreviewDialog.confirmed.connect(_on_preview_confirmed)
     $DialSpinner.confirmed.connect(_on_spinner_confirmed)
     qrb_history_button.pressed.connect(_on_history_pressed)
+    qrb_del_button.pressed.connect(_on_del_pressed)
+    qrb_custom_button.pressed.connect(_on_custom_die_pressed)
+    qrb_custom_dialog.sides_entered.connect(_on_custom_die_entered)
 
 
 func _connect_dice_buttons(row: HBoxContainer) -> void:
@@ -233,3 +239,25 @@ func _on_roll_pressed() -> void:
     qrb_queue.clear()
     qrb_last_faces = 0
     _update_queue_display()
+
+
+func _on_del_pressed() -> void:
+    if qrb_queue.is_empty():
+        return
+    qrb_queue.pop_back()
+    if qrb_queue.is_empty():
+        qrb_last_faces = 0
+    else:
+        qrb_last_faces = qrb_queue[-1]["faces"]
+    _update_queue_display()
+
+
+func _on_custom_die_pressed() -> void:
+    var default_faces: int = qrb_last_faces if qrb_last_faces > 0 else 6
+    qrb_custom_dialog.popup_with_value(default_faces)
+
+
+func _on_custom_die_entered(sides: int) -> void:
+    if sides <= 0:
+        return
+    _add_die(sides, 1)


### PR DESCRIPTION
## Summary
- connect delete button to remove last queued die
- implement `CustomDieDialog` popup for entering custom die faces
- wire DX? button to open the dialog
- update scene with new dialog node

## Testing
- `gdlint LIVEdie/scripts/custom_die_dialog.gd LIVEdie/scripts/quick_roll_bar.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `if ls LIVEdie/*.sln 1> /dev/null 2>&1; then dotnet build --no-restore --nologo > /tmp/dotnet_build.log; else echo "No solution" > /tmp/dotnet_build.log; fi; tail -n 20 /tmp/dotnet_build.log`

------
https://chatgpt.com/codex/tasks/task_e_686b5826eae48329ba82c8cb7e864df4