### PR TITLE
Implement dice delete and custom DX input

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -217,6 +217,10 @@ theme_override_constants/separation = 4
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
 
+[node name="DXInput" type="PopupPanel" parent="QuickRollBar"]
+size = Vector2i(400, 280)
+visible = false
+
 [node name="LongPressTimer" type="Timer" parent="QuickRollBar"]
 wait_time = 0.5
 one_shot = true


### PR DESCRIPTION
## Summary
- allow deleting last dice from quick roll queue
- add DX button input panel for custom dice sides

## Testing
- `gdlint LIVEdie/scripts/quick_roll_bar.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686b5826eae48329ba82c8cb7e864df4