### PR TITLE
Add custom die input and delete function

### DIFF
--- a/LIVEdie/scenes/custom_die_panel.tscn
+++ b/LIVEdie/scenes/custom_die_panel.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=2 format=3 uid="uid://cdpanel01"]
+
+[ext_resource type="Script" uid="uid://cdpanel_gd" path="res://scripts/custom_die_panel.gd" id="1"]
+
+[node name="CustomDiePanel" type="PopupPanel"]
+script = ExtResource("1")
+size = Vector2i(400, 480)
+
+[node name="VBox" type="VBoxContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Display" type="Label" parent="VBox"]
+custom_minimum_size = Vector2(0, 80)
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_font_sizes/font_size = 64
+text = "1"
+
+[node name="Grid" type="GridContainer" parent="VBox"]
+columns = 3

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://qrollbar01"]
+[gd_scene load_steps=5 format=3 uid="uid://qrollbar01"]
 
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://c4jfdeyqiow6v" path="res://scenes/dial_spinner.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://rollhist01" path="res://scenes/roll_history_panel.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://cdpanel01" path="res://scenes/custom_die_panel.tscn" id="4"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -216,6 +217,8 @@ theme_override_constants/separation = 4
 [node name="PreviewDialog" type="AcceptDialog" parent="QuickRollBar"]
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
+
+[node name="CustomDiePanel" parent="QuickRollBar" instance=ExtResource("4")]
 
 [node name="LongPressTimer" type="Timer" parent="QuickRollBar"]
 wait_time = 0.5

--- a/LIVEdie/scripts/custom_die_panel.gd
+++ b/LIVEdie/scripts/custom_die_panel.gd
@@ -1,0 +1,97 @@
+###############################################################
+# LIVEdie/scripts/custom_die_panel.gd
+# Key Classes      • CustomDiePanel – numeric keypad for custom die faces
+# Key Functions    • open_panel_at() – popup keypad near position
+#                   _on_ok_pressed() – confirm selection
+#                   _on_visibility_changed() – cancel on focus loss
+# Editor Exports   • cdp_max_value: int – highest allowed face count
+# Last Major Rev   • 24-06-XX – initial implementation
+###############################################################
+class_name CustomDiePanel
+extends PopupPanel
+
+signal faces_chosen(faces: int)
+
+@export var cdp_max_value: int = 999
+
+var cdp_value: int = 6
+var _confirmed: bool = false
+var _overwrite: bool = false
+
+@onready var _display: Label = $VBox/Display
+@onready var _grid: GridContainer = $VBox/Grid
+
+
+func _ready() -> void:
+    _build_keypad()
+    hide()
+    visibility_changed.connect(_on_visibility_changed)
+
+
+func _build_keypad() -> void:
+    var order := ["7", "8", "9", "4", "5", "6", "1", "2", "3", "DEL", "0", "OK"]
+    for key in order:
+        var btn := Button.new()
+        if key == "DEL":
+            btn.text = "\u232b"
+            btn.pressed.connect(_on_del_pressed)
+        elif key == "OK":
+            btn.text = "\u2714"
+            btn.pressed.connect(_on_ok_pressed)
+        else:
+            btn.text = key
+            btn.pressed.connect(_on_key.bind(key))
+        btn.custom_minimum_size = Vector2(80, 80)
+        btn.add_theme_font_size_override("font_size", 32)
+        _grid.add_child(btn)
+
+
+func open_panel_at(center: Vector2, last_value: int) -> void:
+    cdp_value = clamp(last_value, 1, cdp_max_value)
+    _overwrite = true
+    _confirmed = false
+    _update_display()
+    position = center - Vector2(size) / 2
+    popup()
+
+
+func _update_display() -> void:
+    _display.text = str(cdp_value)
+
+
+func _on_key(ch: String) -> void:
+    var s := "" if _overwrite or cdp_value == 0 else str(cdp_value)
+    _overwrite = false
+    s += ch
+    cdp_value = clamp(int(s), 0, cdp_max_value)
+    _update_display()
+
+
+func _on_del_pressed() -> void:
+    if _overwrite or cdp_value == 0:
+        hide()
+    else:
+        var s := str(cdp_value)
+        if s.length() > 1:
+            s = s.substr(0, s.length() - 1)
+        else:
+            s = "0"
+        cdp_value = int(s)
+        if cdp_value == 0:
+            hide()
+        else:
+            _update_display()
+
+
+func _on_ok_pressed() -> void:
+    if cdp_value == 0:
+        hide()
+        return
+    _confirmed = true
+    hide()
+    emit_signal("faces_chosen", cdp_value)
+
+
+func _on_visibility_changed() -> void:
+    if not visible and not _confirmed:
+        emit_signal("faces_chosen", 0)

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -4,7 +4,7 @@
 # Key Functions    • _on_die_pressed() – queue dice
 #                   _on_long_press_timeout() – handle long press
 # Critical Consts  • QRB_SUPERSCRIPTS – digits for display
-# Dependencies     • DiceParser
+# Dependencies     • DiceParser, CustomDiePanel
 # Last Major Rev   • 24-04-XX – initial implementation
 ###############################################################
 class_name QuickRollBar
@@ -25,6 +25,7 @@ const QRB_SUPERSCRIPTS := {
 
 var qrb_queue: Array = []
 var qrb_last_faces: int = 0
+var qrb_last_custom_faces: int = 6
 var qrb_prev_queue: Array = []
 var qrb_long_press_type: String = ""
 var qrb_long_press_param: int = 0
@@ -34,6 +35,7 @@ var qrb_long_press_button: Control
 @onready var qrb_chip_box: HBoxContainer = $QueueRow/HScroll/DiceChips
 @onready var qrb_history_button: Button = $"../HistoryButton"
 @onready var qrb_history_panel: RollHistoryPanel = $"../RollHistoryPanel"
+@onready var qrb_custom_panel: CustomDiePanel = $CustomDiePanel
 
 
 func _ready() -> void:
@@ -46,6 +48,9 @@ func _ready() -> void:
     $PreviewDialog.confirmed.connect(_on_preview_confirmed)
     $DialSpinner.confirmed.connect(_on_spinner_confirmed)
     qrb_history_button.pressed.connect(_on_history_pressed)
+    $RepeaterRow/DieX.pressed.connect(_on_custom_die_pressed)
+    $RepeaterRow/DieX2.pressed.connect(_on_del_button_pressed)
+    qrb_custom_panel.faces_chosen.connect(_on_custom_faces_chosen)
 
 
 func _connect_dice_buttons(row: HBoxContainer) -> void:
@@ -127,6 +132,29 @@ func _on_repeat_up(mult: int, _btn: Button) -> void:
         pass
     else:
         _on_repeat_pressed(mult)
+
+
+func _on_del_button_pressed() -> void:
+    if qrb_queue.is_empty():
+        return
+    qrb_queue.pop_back()
+    if qrb_queue.is_empty():
+        qrb_last_faces = 0
+    else:
+        qrb_last_faces = qrb_queue[-1]["faces"]
+    _update_queue_display()
+
+
+func _on_custom_die_pressed() -> void:
+    var center := Vector2($RepeaterRow/DieX.get_global_rect().get_center())
+    qrb_custom_panel.open_panel_at(center, qrb_last_custom_faces)
+
+
+func _on_custom_faces_chosen(faces: int) -> void:
+    if faces <= 0:
+        return
+    qrb_last_custom_faces = faces
+    _add_die(faces, 1)
 
 
 func _add_die(faces: int, qty: int) -> void:


### PR DESCRIPTION
## Summary
- implement `CustomDiePanel` for entering custom sided dice
- hook up DX? and Delete buttons in quick roll bar
- store last custom die choice for convenience

## Testing
- `bash .codex/fix_indent.sh LIVEdie/scripts/custom_die_panel.gd LIVEdie/scripts/quick_roll_bar.gd`
- `gdlint LIVEdie/scripts/custom_die_panel.gd LIVEdie/scripts/quick_roll_bar.gd`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_686b5826eae48329ba82c8cb7e864df4