### PR TITLE
Add custom die input and delete action

### DIFF
--- a/LIVEdie/scenes/custom_die_input.tscn
+++ b/LIVEdie/scenes/custom_die_input.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/custom_die_input.gd" id="1"]
+
+[node name="CustomDieInput" type="PopupPanel"]
+script = ExtResource("1")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme_override_constants/separation = 10
+
+[node name="ValueLabel" type="Label" parent="VBox"]
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_font_sizes/font_size = 60
+text = "0"
+
+[node name="Grid" type="GridContainer" parent="VBox"]
+columns = 3
+

--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://c4jfdeyqiow6v" path="res://scenes/dial_spinner.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://rollhist01" path="res://scenes/roll_history_panel.tscn" id="3"]
+[ext_resource type="PackedScene" path="res://scenes/custom_die_input.tscn" id="4"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -222,6 +223,7 @@ theme_override_constants/separation = 4
 [node name="PreviewDialog" type="AcceptDialog" parent="QuickRollBar"]
 
 [node name="DialSpinner" parent="QuickRollBar" instance=ExtResource("2")]
+[node name="CustomDieInput" parent="QuickRollBar" instance=ExtResource("4")]
 
 [node name="LongPressTimer" type="Timer" parent="QuickRollBar"]
 wait_time = 0.5

--- a/LIVEdie/scripts/custom_die_input.gd
+++ b/LIVEdie/scripts/custom_die_input.gd
@@ -1,0 +1,99 @@
+###############################################################
+# LIVEdie/scripts/custom_die_input.gd
+# Key Classes      • CustomDieInput – keypad for die face input
+# Key Functions    • open_input() – open keypad with initial value
+# Dependencies     • none
+# Last Major Rev   • 24-06-XX – initial version
+###############################################################
+class_name CustomDieInput
+extends PopupPanel
+
+signal confirmed(value: int)
+signal cancelled
+
+@export var cdi_max_value: int = 999
+
+var cdi_value: int = 0
+var _replace: bool = true
+
+@onready var _label: Label = $VBox/ValueLabel
+@onready var _grid: GridContainer = $VBox/Grid
+
+
+func _ready() -> void:
+    _build_keypad()
+    hide()
+
+
+func _build_keypad() -> void:
+    var order := ["7", "8", "9", "4", "5", "6", "1", "2", "3", "DEL", "0", "OK"]
+    for key in order:
+        var btn := Button.new()
+        if key == "DEL":
+            btn.text = "\u232b"
+        elif key == "OK":
+            btn.text = "\u2714"
+        else:
+            btn.text = key
+        btn.custom_minimum_size = Vector2(80, 80)
+        btn.add_theme_font_size_override("font_size", 32)
+        _grid.add_child(btn)
+        if key.is_valid_int():
+            btn.pressed.connect(_on_digit.bind(int(key)))
+        elif key == "OK":
+            btn.pressed.connect(_on_ok)
+        else:
+            btn.pressed.connect(_on_del)
+
+
+func open_input(initial: int) -> void:
+    cdi_value = clamp(initial, 0, cdi_max_value)
+    _replace = true
+    _update_label()
+    popup_centered()
+
+
+func _on_digit(d: int) -> void:
+    if _replace:
+        cdi_value = d
+        _replace = false
+    else:
+        var new_val: int = clamp(cdi_value * 10 + d, 0, cdi_max_value)
+        cdi_value = new_val
+    _update_label()
+
+
+func _on_ok() -> void:
+    hide()
+    if cdi_value == 0:
+        emit_signal("cancelled")
+    else:
+        emit_signal("confirmed", cdi_value)
+
+
+func _on_del() -> void:
+    if _replace or cdi_value == 0:
+        hide()
+        emit_signal("cancelled")
+        return
+    var s := str(cdi_value)
+    s = s.substr(0, s.length() - 1)
+    if s == "":
+        cdi_value = 0
+        _replace = true
+    else:
+        cdi_value = int(s)
+    _update_label()
+
+
+func _update_label() -> void:
+    _label.text = str(cdi_value)
+
+
+func _input(event: InputEvent) -> void:
+    if not visible:
+        return
+    if event is InputEventMouseButton or event is InputEventScreenTouch:
+        if not event.pressed:
+            hide()
+            emit_signal("cancelled")

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -30,10 +30,12 @@ var qrb_long_press_type: String = ""
 var qrb_long_press_param: int = 0
 var qrb_long_press_triggered: bool = false
 var qrb_long_press_button: Control
+var qrb_last_custom_faces: int = 6
 
 @onready var qrb_chip_box: HBoxContainer = $QueueRow/HScroll/DiceChips
 @onready var qrb_history_button: Button = $"../HistoryButton"
 @onready var qrb_history_panel: RollHistoryPanel = $"../RollHistoryPanel"
+@onready var qrb_custom_panel: CustomDieInput = $CustomDieInput
 
 
 func _ready() -> void:
@@ -46,6 +48,9 @@ func _ready() -> void:
     $PreviewDialog.confirmed.connect(_on_preview_confirmed)
     $DialSpinner.confirmed.connect(_on_spinner_confirmed)
     qrb_history_button.pressed.connect(_on_history_pressed)
+    $RepeaterRow/DelButton.pressed.connect(_on_delete_pressed)
+    $RepeaterRow/DieX.pressed.connect(_on_custom_die_pressed)
+    qrb_custom_panel.confirmed.connect(_on_custom_die_confirmed)
 
 
 func _connect_dice_buttons(row: HBoxContainer) -> void:
@@ -233,3 +238,23 @@ func _on_roll_pressed() -> void:
     qrb_queue.clear()
     qrb_last_faces = 0
     _update_queue_display()
+
+
+func _on_delete_pressed() -> void:
+    if qrb_queue.is_empty():
+        return
+    qrb_queue.pop_back()
+    if qrb_queue.is_empty():
+        qrb_last_faces = 0
+    else:
+        qrb_last_faces = qrb_queue[-1]["faces"]
+    _update_queue_display()
+
+
+func _on_custom_die_pressed() -> void:
+    qrb_custom_panel.open_input(qrb_last_custom_faces)
+
+
+func _on_custom_die_confirmed(value: int) -> void:
+    qrb_last_custom_faces = value
+    _add_die(value, 1)


### PR DESCRIPTION
## Summary
- implement `CustomDieInput` keypad popup
- hook into `DieX` button to allow custom face entry
- allow `DelButton` to remove the last dice entry

## Testing
- `gdlint $(git diff --name-only --cached -- '*.gd')`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_686b8fc4db888329b1c235bc06e2d78f