### PR TITLE
Add scalable quick roll bar

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -12,6 +12,7 @@ anchor_right = 1.0
 offset_bottom = 293.0
 grow_horizontal = 2
 size_flags_horizontal = 3
+qrb_button_scale_idx = 0
 theme_override_constants/separation = 25
 script = ExtResource("1")
 


### PR DESCRIPTION
## Summary
- expose quick bar button scale in inspector
- compute base sizes and resize buttons dynamically
- update quick roll bar scene to store scale value

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo` *(fails: no project)*

------
https://chatgpt.com/codex/tasks/task_e_686be5872fb88329b5559430a27568b7