### PR TITLE
Use emoji font; customizable text size

### DIFF
--- a/LIVEdie/project.godot
+++ b/LIVEdie/project.godot
@@ -34,3 +34,6 @@ input_devices/pointing/emulate_touch_from_mouse=true
 [rendering]
 
 renderer/rendering_method="mobile"
+
+[gui]
+theme/default_font="res://fonts/NotoColorEmoji-Regular.ttf"

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -10,6 +10,8 @@
 class_name QuickRollBar
 extends VBoxContainer
 
+const QRB_FONT := preload("res://fonts/NotoColorEmoji-Regular.ttf")
+
 const QRB_SUPERSCRIPTS := {
     "0": "\u2070",
     "1": "\u00B9",
@@ -29,6 +31,12 @@ const QRB_SUPERSCRIPTS := {
         if is_inside_tree():
             _qrb_apply_scale()
 
+# Font sizes for quickbar elements. They are multiplied by `qrb_size_index`
+# in `_qrb_apply_scale()`.
+@export var qrb_button_font_size: int = 35
+@export var qrb_roll_font_size: int = 28
+@export var qrb_queue_font_size: int = 24
+
 var qrb_queue: Array = []
 var qrb_last_faces: int = 0
 var qrb_prev_queue: Array = []
@@ -47,6 +55,7 @@ var qrb_faces_commit: bool = false
 @onready var qrb_history_button: Button = $"../HistoryButton"
 @onready var qrb_history_panel: RollHistoryPanel = $"../RollHistoryPanel"
 
+
 func _ready() -> void:
     _connect_dice_buttons($StandardRow)
     _connect_dice_buttons($AdvancedRow)
@@ -61,6 +70,8 @@ func _ready() -> void:
     $RepeaterRow/DieX.pressed.connect(_on_die_x_pressed)
     _build_custom_panel()
     _qrb_apply_scale()
+    qrb_history_button.add_theme_font_override("font", QRB_FONT)
+
 
 func _connect_dice_buttons(row: Container) -> void:
     for node in row.get_children():
@@ -75,6 +86,7 @@ func _connect_dice_buttons(row: Container) -> void:
             node.button_down.connect(_on_die_down.bind(faces, node))
             node.button_up.connect(_on_die_up.bind(faces, node))
 
+
 func _connect_repeat_buttons() -> void:
     for node in $RepeaterRow.get_children():
         if node is Button and node.name.begins_with("X"):
@@ -82,11 +94,14 @@ func _connect_repeat_buttons() -> void:
             node.button_down.connect(_on_repeat_down.bind(mult, node))
             node.button_up.connect(_on_repeat_up.bind(mult, node))
 
+
 func _on_toggle_advanced() -> void:
     $AdvancedRow.visible = not $AdvancedRow.visible
 
+
 func _on_die_pressed(faces: int) -> void:
     _add_die(faces, 1)
+
 
 func _on_repeat_pressed(mult: int) -> void:
     if qrb_last_faces == 0:
@@ -100,6 +115,7 @@ func _on_repeat_pressed(mult: int) -> void:
     else:
         _add_die(qrb_last_faces, mult)
 
+
 func _on_die_down(faces: int, btn: Button) -> void:
     qrb_long_press_type = "die"
     qrb_long_press_param = faces
@@ -107,6 +123,7 @@ func _on_die_down(faces: int, btn: Button) -> void:
     qrb_long_press_button = btn
     if not Engine.is_editor_hint() and $LongPressTimer.is_inside_tree():
         $LongPressTimer.start()
+
 
 func _on_die_up(faces: int, _btn: Button) -> void:
     if $LongPressTimer.time_left > 0.0:
@@ -117,6 +134,7 @@ func _on_die_up(faces: int, _btn: Button) -> void:
     else:
         _on_die_pressed(faces)
 
+
 func _on_repeat_down(mult: int, btn: Button) -> void:
     qrb_long_press_type = "repeat"
     qrb_long_press_param = mult
@@ -124,6 +142,7 @@ func _on_repeat_down(mult: int, btn: Button) -> void:
     qrb_long_press_button = btn
     if not Engine.is_editor_hint() and $LongPressTimer.is_inside_tree():
         $LongPressTimer.start()
+
 
 func _on_repeat_up(mult: int, _btn: Button) -> void:
     if $LongPressTimer.time_left > 0.0:
@@ -134,6 +153,7 @@ func _on_repeat_up(mult: int, _btn: Button) -> void:
     else:
         _on_repeat_pressed(mult)
 
+
 func _add_die(faces: int, qty: int) -> void:
     if qrb_queue.is_empty() or qrb_queue[-1]["faces"] != faces:
         qrb_queue.append({"faces": faces, "count": qty})
@@ -141,6 +161,7 @@ func _add_die(faces: int, qty: int) -> void:
         qrb_queue[-1]["count"] += qty
     qrb_last_faces = faces
     _update_queue_display()
+
 
 func _update_queue_display() -> void:
     for child in qrb_chip_box.get_children():
@@ -152,11 +173,14 @@ func _update_queue_display() -> void:
     for entry in qrb_queue:
         var chip := Label.new()
         chip.text = "D%d × %d" % [entry["faces"], entry["count"]]
-        chip.scale = Vector2(1.5, 1.5) 
-        chip.custom_minimum_size = Vector2(90, 40)
+        chip.scale = Vector2(1.5, 1.5) * qrb_size_index
+        chip.custom_minimum_size = Vector2(90, 40) * qrb_size_index
+        chip.add_theme_font_size_override("font_size", int(qrb_queue_font_size * qrb_size_index))
+        chip.add_theme_font_override("font", QRB_FONT)
         chip.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
         chip.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
         qrb_chip_box.add_child(chip)
+
 
 func _superscript(val: int) -> String:
     var result := ""
@@ -164,11 +188,13 @@ func _superscript(val: int) -> String:
         result += QRB_SUPERSCRIPTS.get(c, c)
     return result
 
+
 func _build_expression() -> String:
     var parts: Array = []
     for entry in qrb_queue:
         parts.append(str(entry["count"]) + "d" + str(entry["faces"]))
     return " + ".join(parts)
+
 
 func _on_long_press_timeout() -> void:
     qrb_long_press_triggered = true
@@ -176,6 +202,7 @@ func _on_long_press_timeout() -> void:
         _show_multiplier_preview(qrb_long_press_param)
     elif qrb_long_press_type == "die":
         _show_spinner(qrb_long_press_param)
+
 
 func _show_multiplier_preview(mult: int) -> void:
     var preview: Array = []
@@ -190,8 +217,10 @@ func _show_multiplier_preview(mult: int) -> void:
     $PreviewDialog.dialog_text = " -> ".join(parts)
     $PreviewDialog.popup_centered()
 
+
 func _on_preview_confirmed() -> void:
     _apply_multiplier(qrb_long_press_param)
+
 
 func _apply_multiplier(mult: int) -> void:
     qrb_prev_queue = qrb_queue.duplicate(true)
@@ -199,21 +228,25 @@ func _apply_multiplier(mult: int) -> void:
         entry["count"] *= mult
     _update_queue_display()
 
+
 func _show_spinner(faces: int) -> void:
     qrb_long_press_param = faces
     $DialSpinner.ds_value = 1
     var center := qrb_long_press_button.get_global_rect().get_center()
     $DialSpinner.open_dial_at(center)
 
+
 func _on_spinner_confirmed() -> void:
     var qty := int($DialSpinner.ds_value)
     _add_die(qrb_long_press_param, qty)
+
 
 func _on_history_pressed() -> void:
     if qrb_history_panel.visible:
         qrb_history_panel.hide_panel()
     else:
         qrb_history_panel.show_panel()
+
 
 func _on_roll_pressed() -> void:
     if qrb_queue.is_empty():
@@ -229,6 +262,7 @@ func _on_roll_pressed() -> void:
     qrb_last_faces = 0
     _update_queue_display()
 
+
 func _on_del_pressed() -> void:
     if qrb_queue.is_empty():
         return
@@ -239,11 +273,13 @@ func _on_del_pressed() -> void:
         qrb_last_faces = qrb_queue[-1]["faces"]
     _update_queue_display()
 
+
 func _on_die_x_pressed() -> void:
     qrb_faces_replace = true
     qrb_faces_value = qrb_faces_value if qrb_faces_value > 0 else 6
     _update_faces_label()
     qrb_faces_panel.popup_centered()
+
 
 func _on_faces_key(ch: String) -> void:
     var s := str(qrb_faces_value)
@@ -258,6 +294,7 @@ func _on_faces_key(ch: String) -> void:
     qrb_faces_value = clamp(int(s), 0, 9999)
     _update_faces_label()
 
+
 func _on_faces_del() -> void:
     if qrb_faces_replace or str(qrb_faces_value) == "0":
         qrb_faces_panel.hide()
@@ -269,12 +306,14 @@ func _on_faces_del() -> void:
     qrb_faces_value = int(s)
     _update_faces_label()
 
+
 func _on_faces_ok() -> void:
     if qrb_faces_value == 0:
         qrb_faces_panel.hide()
         return
     qrb_faces_commit = true
     qrb_faces_panel.hide()
+
 
 func _on_faces_panel_hide() -> void:
     if qrb_faces_commit:
@@ -283,9 +322,11 @@ func _on_faces_panel_hide() -> void:
         qrb_last_faces = faces
         _add_die(faces, 1)
 
+
 func _update_faces_label() -> void:
     if qrb_faces_label:
         qrb_faces_label.text = str(qrb_faces_value)
+
 
 func _build_custom_panel() -> void:
     qrb_faces_panel = PopupPanel.new()
@@ -294,6 +335,7 @@ func _build_custom_panel() -> void:
     qrb_faces_label = Label.new()
     qrb_faces_label.custom_minimum_size.y = 60
     qrb_faces_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    qrb_faces_label.add_theme_font_override("font", QRB_FONT)
     var vbox := VBoxContainer.new()
     vbox.add_child(qrb_faces_label)
     var grid := GridContainer.new()
@@ -304,6 +346,7 @@ func _build_custom_panel() -> void:
         var btn := Button.new()
         btn.custom_minimum_size = Vector2(80, 80)
         btn.add_theme_font_size_override("font_size", 32)
+        btn.add_theme_font_override("font", QRB_FONT)
         if key == "DEL":
             btn.text = "\u232b"
         elif key == "OK":
@@ -320,6 +363,7 @@ func _build_custom_panel() -> void:
     qrb_faces_panel.add_child(vbox)
     add_child(qrb_faces_panel)
 
+
 func _qrb_all_buttons() -> Array:
     var result: Array = []
     for n in $StandardRow.get_children():
@@ -333,11 +377,12 @@ func _qrb_all_buttons() -> Array:
             result.append(n)
     return result
 
+
 func _qrb_apply_scale() -> void:
     var scale: float = qrb_size_index
     var base: Vector2 = Vector2(80, 80) * scale
-    var std_font: int = int(35 * scale)
-    var roll_font: int = int(28 * scale)
+    var std_font: int = int(qrb_button_font_size * scale)
+    var roll_font: int = int(qrb_roll_font_size * scale)
     add_theme_constant_override("separation", int(25 * scale))
     $StandardRow.add_theme_constant_override("separation", int(30 * scale))
     $AdvancedRow.add_theme_constant_override("separation", int(30 * scale))
@@ -348,3 +393,4 @@ func _qrb_apply_scale() -> void:
         if btn == $RepeaterRow/RollButton:
             size = roll_font
         btn.add_theme_font_size_override("font_size", size)
+        btn.add_theme_font_override("font", QRB_FONT)

--- a/LIVEdie/scripts/roll_history_panel.gd
+++ b/LIVEdie/scripts/roll_history_panel.gd
@@ -10,6 +10,10 @@
 class_name RollHistoryPanel
 extends PanelContainer
 
+const RHP_FONT := preload("res://fonts/NotoColorEmoji-Regular.ttf")
+
+@export var rhp_font_size: int = 24
+
 @onready var _entries: VBoxContainer = $Scroll/Entries
 
 
@@ -17,7 +21,11 @@ func add_entry(text: String) -> void:
     var label := Label.new()
     label.text = text
     label.custom_minimum_size.y = 48
+    label.add_theme_font_size_override("font_size", rhp_font_size)
+    label.add_theme_font_override("font", RHP_FONT)
     _entries.add_child(label)
+    _entries.move_child(label, 0)
+    call_deferred("_scroll_to_top")
 
 
 func show_panel() -> void:
@@ -26,3 +34,7 @@ func show_panel() -> void:
 
 func hide_panel() -> void:
     hide()
+
+
+func _scroll_to_top() -> void:
+    $Scroll.scroll_vertical = 0


### PR DESCRIPTION
## Summary
- switch project default font to NotoColorEmoji-Regular
- allow custom font sizes for quickbar buttons, queue items and history entries
- move history log entries to the top and scroll to latest automatically
- apply new font to quickbar and history widgets

## Testing
- `godot --headless --script res://tests/test_dice_parser.gd` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ce32c208329a718c3ba145b38e6