### PR TITLE
Add global fonts and adjustable text sizes

### DIFF
--- a/LIVEdie/main.tscn
+++ b/LIVEdie/main.tscn
@@ -1,8 +1,10 @@
 [gd_scene load_steps=2 format=3 uid="uid://60wyaydkyepa"]
 
 [ext_resource type="PackedScene" uid="uid://qrollbar01" path="res://scenes/quick_roll_bar.tscn" id="1"]
+[ext_resource type="Script" path="res://scripts/main.gd" id="2"]
 
 [node name="Main" type="Control"]
+script = ExtResource("2")
 custom_minimum_size = Vector2(200, 200)
 layout_mode = 3
 anchors_preset = 15

--- a/LIVEdie/scripts/main.gd
+++ b/LIVEdie/scripts/main.gd
@@ -1,0 +1,20 @@
+###############################################################
+# LIVEdie/scripts/main.gd
+# Key Classes      • Main – project root
+# Key Functions    • _ready() – apply default fonts
+# Critical Consts  • none
+# Dependencies     • none
+# Last Major Rev   • 24-07-XX – set global fonts
+###############################################################
+extends Control
+
+@export var main_default_font_size: int = 32
+
+
+func _ready() -> void:
+    var theme := ThemeDB.get_default_theme()
+    var base_font: Font = load("res://fonts/NotoSans-VariableFont_wdth,wght.ttf")
+    var emoji_font: Font = load("res://fonts/NotoColorEmoji-Regular.ttf")
+    base_font.fallbacks = [emoji_font]
+    theme.default_font = base_font
+    theme.default_font_size = main_default_font_size

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -29,6 +29,10 @@ const QRB_SUPERSCRIPTS := {
         if is_inside_tree():
             _qrb_apply_scale()
 
+@export var qrb_button_font_size: int = 35
+@export var qrb_roll_button_font_size: int = 28
+@export var qrb_chip_font_size: int = 24
+
 var qrb_queue: Array = []
 var qrb_last_faces: int = 0
 var qrb_prev_queue: Array = []
@@ -47,6 +51,7 @@ var qrb_faces_commit: bool = false
 @onready var qrb_history_button: Button = $"../HistoryButton"
 @onready var qrb_history_panel: RollHistoryPanel = $"../RollHistoryPanel"
 
+
 func _ready() -> void:
     _connect_dice_buttons($StandardRow)
     _connect_dice_buttons($AdvancedRow)
@@ -62,6 +67,7 @@ func _ready() -> void:
     _build_custom_panel()
     _qrb_apply_scale()
 
+
 func _connect_dice_buttons(row: Container) -> void:
     for node in row.get_children():
         if (
@@ -75,6 +81,7 @@ func _connect_dice_buttons(row: Container) -> void:
             node.button_down.connect(_on_die_down.bind(faces, node))
             node.button_up.connect(_on_die_up.bind(faces, node))
 
+
 func _connect_repeat_buttons() -> void:
     for node in $RepeaterRow.get_children():
         if node is Button and node.name.begins_with("X"):
@@ -82,11 +89,14 @@ func _connect_repeat_buttons() -> void:
             node.button_down.connect(_on_repeat_down.bind(mult, node))
             node.button_up.connect(_on_repeat_up.bind(mult, node))
 
+
 func _on_toggle_advanced() -> void:
     $AdvancedRow.visible = not $AdvancedRow.visible
 
+
 func _on_die_pressed(faces: int) -> void:
     _add_die(faces, 1)
+
 
 func _on_repeat_pressed(mult: int) -> void:
     if qrb_last_faces == 0:
@@ -100,6 +110,7 @@ func _on_repeat_pressed(mult: int) -> void:
     else:
         _add_die(qrb_last_faces, mult)
 
+
 func _on_die_down(faces: int, btn: Button) -> void:
     qrb_long_press_type = "die"
     qrb_long_press_param = faces
@@ -107,6 +118,7 @@ func _on_die_down(faces: int, btn: Button) -> void:
     qrb_long_press_button = btn
     if not Engine.is_editor_hint() and $LongPressTimer.is_inside_tree():
         $LongPressTimer.start()
+
 
 func _on_die_up(faces: int, _btn: Button) -> void:
     if $LongPressTimer.time_left > 0.0:
@@ -117,6 +129,7 @@ func _on_die_up(faces: int, _btn: Button) -> void:
     else:
         _on_die_pressed(faces)
 
+
 func _on_repeat_down(mult: int, btn: Button) -> void:
     qrb_long_press_type = "repeat"
     qrb_long_press_param = mult
@@ -124,6 +137,7 @@ func _on_repeat_down(mult: int, btn: Button) -> void:
     qrb_long_press_button = btn
     if not Engine.is_editor_hint() and $LongPressTimer.is_inside_tree():
         $LongPressTimer.start()
+
 
 func _on_repeat_up(mult: int, _btn: Button) -> void:
     if $LongPressTimer.time_left > 0.0:
@@ -134,6 +148,7 @@ func _on_repeat_up(mult: int, _btn: Button) -> void:
     else:
         _on_repeat_pressed(mult)
 
+
 func _add_die(faces: int, qty: int) -> void:
     if qrb_queue.is_empty() or qrb_queue[-1]["faces"] != faces:
         qrb_queue.append({"faces": faces, "count": qty})
@@ -141,6 +156,7 @@ func _add_die(faces: int, qty: int) -> void:
         qrb_queue[-1]["count"] += qty
     qrb_last_faces = faces
     _update_queue_display()
+
 
 func _update_queue_display() -> void:
     for child in qrb_chip_box.get_children():
@@ -152,11 +168,13 @@ func _update_queue_display() -> void:
     for entry in qrb_queue:
         var chip := Label.new()
         chip.text = "D%d × %d" % [entry["faces"], entry["count"]]
-        chip.scale = Vector2(1.5, 1.5) 
+        chip.scale = Vector2(1.5, 1.5)
         chip.custom_minimum_size = Vector2(90, 40)
         chip.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
         chip.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+        chip.add_theme_font_size_override("font_size", qrb_chip_font_size)
         qrb_chip_box.add_child(chip)
+
 
 func _superscript(val: int) -> String:
     var result := ""
@@ -164,11 +182,13 @@ func _superscript(val: int) -> String:
         result += QRB_SUPERSCRIPTS.get(c, c)
     return result
 
+
 func _build_expression() -> String:
     var parts: Array = []
     for entry in qrb_queue:
         parts.append(str(entry["count"]) + "d" + str(entry["faces"]))
     return " + ".join(parts)
+
 
 func _on_long_press_timeout() -> void:
     qrb_long_press_triggered = true
@@ -176,6 +196,7 @@ func _on_long_press_timeout() -> void:
         _show_multiplier_preview(qrb_long_press_param)
     elif qrb_long_press_type == "die":
         _show_spinner(qrb_long_press_param)
+
 
 func _show_multiplier_preview(mult: int) -> void:
     var preview: Array = []
@@ -190,8 +211,10 @@ func _show_multiplier_preview(mult: int) -> void:
     $PreviewDialog.dialog_text = " -> ".join(parts)
     $PreviewDialog.popup_centered()
 
+
 func _on_preview_confirmed() -> void:
     _apply_multiplier(qrb_long_press_param)
+
 
 func _apply_multiplier(mult: int) -> void:
     qrb_prev_queue = qrb_queue.duplicate(true)
@@ -199,21 +222,25 @@ func _apply_multiplier(mult: int) -> void:
         entry["count"] *= mult
     _update_queue_display()
 
+
 func _show_spinner(faces: int) -> void:
     qrb_long_press_param = faces
     $DialSpinner.ds_value = 1
     var center := qrb_long_press_button.get_global_rect().get_center()
     $DialSpinner.open_dial_at(center)
 
+
 func _on_spinner_confirmed() -> void:
     var qty := int($DialSpinner.ds_value)
     _add_die(qrb_long_press_param, qty)
+
 
 func _on_history_pressed() -> void:
     if qrb_history_panel.visible:
         qrb_history_panel.hide_panel()
     else:
         qrb_history_panel.show_panel()
+
 
 func _on_roll_pressed() -> void:
     if qrb_queue.is_empty():
@@ -229,6 +256,7 @@ func _on_roll_pressed() -> void:
     qrb_last_faces = 0
     _update_queue_display()
 
+
 func _on_del_pressed() -> void:
     if qrb_queue.is_empty():
         return
@@ -239,11 +267,13 @@ func _on_del_pressed() -> void:
         qrb_last_faces = qrb_queue[-1]["faces"]
     _update_queue_display()
 
+
 func _on_die_x_pressed() -> void:
     qrb_faces_replace = true
     qrb_faces_value = qrb_faces_value if qrb_faces_value > 0 else 6
     _update_faces_label()
     qrb_faces_panel.popup_centered()
+
 
 func _on_faces_key(ch: String) -> void:
     var s := str(qrb_faces_value)
@@ -258,6 +288,7 @@ func _on_faces_key(ch: String) -> void:
     qrb_faces_value = clamp(int(s), 0, 9999)
     _update_faces_label()
 
+
 func _on_faces_del() -> void:
     if qrb_faces_replace or str(qrb_faces_value) == "0":
         qrb_faces_panel.hide()
@@ -269,12 +300,14 @@ func _on_faces_del() -> void:
     qrb_faces_value = int(s)
     _update_faces_label()
 
+
 func _on_faces_ok() -> void:
     if qrb_faces_value == 0:
         qrb_faces_panel.hide()
         return
     qrb_faces_commit = true
     qrb_faces_panel.hide()
+
 
 func _on_faces_panel_hide() -> void:
     if qrb_faces_commit:
@@ -283,9 +316,11 @@ func _on_faces_panel_hide() -> void:
         qrb_last_faces = faces
         _add_die(faces, 1)
 
+
 func _update_faces_label() -> void:
     if qrb_faces_label:
         qrb_faces_label.text = str(qrb_faces_value)
+
 
 func _build_custom_panel() -> void:
     qrb_faces_panel = PopupPanel.new()
@@ -303,7 +338,7 @@ func _build_custom_panel() -> void:
     for key in order:
         var btn := Button.new()
         btn.custom_minimum_size = Vector2(80, 80)
-        btn.add_theme_font_size_override("font_size", 32)
+        btn.add_theme_font_size_override("font_size", qrb_button_font_size)
         if key == "DEL":
             btn.text = "\u232b"
         elif key == "OK":
@@ -320,6 +355,7 @@ func _build_custom_panel() -> void:
     qrb_faces_panel.add_child(vbox)
     add_child(qrb_faces_panel)
 
+
 func _qrb_all_buttons() -> Array:
     var result: Array = []
     for n in $StandardRow.get_children():
@@ -333,11 +369,12 @@ func _qrb_all_buttons() -> Array:
             result.append(n)
     return result
 
+
 func _qrb_apply_scale() -> void:
     var scale: float = qrb_size_index
     var base: Vector2 = Vector2(80, 80) * scale
-    var std_font: int = int(35 * scale)
-    var roll_font: int = int(28 * scale)
+    var std_font: int = int(qrb_button_font_size * scale)
+    var roll_font: int = int(qrb_roll_button_font_size * scale)
     add_theme_constant_override("separation", int(25 * scale))
     $StandardRow.add_theme_constant_override("separation", int(30 * scale))
     $AdvancedRow.add_theme_constant_override("separation", int(30 * scale))

--- a/LIVEdie/scripts/roll_history_panel.gd
+++ b/LIVEdie/scripts/roll_history_panel.gd
@@ -9,6 +9,7 @@
 ###############################################################
 class_name RollHistoryPanel
 extends PanelContainer
+@export var rhp_entry_font_size: int = 24
 
 @onready var _entries: VBoxContainer = $Scroll/Entries
 
@@ -17,7 +18,10 @@ func add_entry(text: String) -> void:
     var label := Label.new()
     label.text = text
     label.custom_minimum_size.y = 48
+    label.add_theme_font_size_override("font_size", rhp_entry_font_size)
     _entries.add_child(label)
+    _entries.move_child(label, 0)
+    $Scroll.scroll_vertical = 0
 
 
 func show_panel() -> void:


### PR DESCRIPTION
## Summary
- set up global `Noto Sans`/`Noto Color Emoji` fonts via new `main.gd`
- expose font size exports in `QuickRollBar` and `RollHistoryPanel`
- add queue chip font override
- show newest history entries first

## Testing
- `gdlint $(git diff --name-only -- '*.gd')`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_686c549621dc8329bc0ffff99600ca2a