### PR TITLE
Add glyph overlays for dice buttons

### DIFF
--- a/LIVEdie/scenes/quick_roll_bar.tscn
+++ b/LIVEdie/scenes/quick_roll_bar.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://owkgt6c75kui" path="res://scripts/quick_roll_bar.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://c4jfdeyqiow6v" path="res://scenes/dial_spinner.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://rollhist01" path="res://scenes/roll_history_panel.tscn" id="3"]
+[ext_resource type="Script" uid="uid://diebutton01" path="res://scripts/die_button.gd" id="4"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -95,18 +96,33 @@ alignment = 1
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
+script = ExtResource("4")
+db_faces = 4
+db_shape_glyph = "\u25B2"
+db_shape_color = Color(1, 0, 0, 1)
+db_number_color = Color(1, 1, 1, 1)
 text = "D4"
 
 [node name="Die6" type="Button" parent="QuickRollBar/StandardRow"]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
+script = ExtResource("4")
+db_faces = 6
+db_shape_glyph = "\u25A0"
+db_shape_color = Color(0, 0.6, 0, 1)
+db_number_color = Color(1, 1, 1, 1)
 text = "D6"
 
 [node name="Die8" type="Button" parent="QuickRollBar/StandardRow"]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
+script = ExtResource("4")
+db_faces = 8
+db_shape_glyph = "\u2B1F"
+db_shape_color = Color(0, 0.4, 1, 1)
+db_number_color = Color(1, 1, 1, 1)
 text = "D8"
 
 [node name="Die10" type="Button" parent="QuickRollBar/StandardRow"]
@@ -114,18 +130,33 @@ visible = false
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
+script = ExtResource("4")
+db_faces = 10
+db_shape_glyph = "\u2B19"
+db_shape_color = Color(0.5, 0, 0.8, 1)
+db_number_color = Color(1, 1, 1, 1)
 text = "D10"
 
 [node name="Die12" type="Button" parent="QuickRollBar/StandardRow"]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
+script = ExtResource("4")
+db_faces = 12
+db_shape_glyph = "\u2B22"
+db_shape_color = Color(1, 0.5, 0, 1)
+db_number_color = Color(1, 1, 1, 1)
 text = "D12"
 
 [node name="Die20" type="Button" parent="QuickRollBar/StandardRow"]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
+script = ExtResource("4")
+db_faces = 20
+db_shape_glyph = "\u272A"
+db_shape_color = Color(1, 0.84, 0, 1)
+db_number_color = Color(1, 1, 1, 1)
 text = "D20"
 
 [node name="Die100" type="Button" parent="QuickRollBar/StandardRow"]

--- a/LIVEdie/scripts/die_button.gd
+++ b/LIVEdie/scripts/die_button.gd
@@ -1,0 +1,75 @@
+###############################################################
+# LIVEdie/scripts/die_button.gd
+# Key Classes      • DieButton – button with dice glyph overlay
+# Key Functions    • _update_glyphs() – refresh label styles
+# Critical Consts  • none
+# Dependencies     • none
+# Last Major Rev   • 24-06-XX – initial implementation
+###############################################################
+class_name DieButton
+extends Button
+
+@export var db_faces: int = 4:
+    set(value):
+        db_faces = value
+        if is_inside_tree():
+            _update_glyphs()
+
+@export var db_shape_glyph: String = "▲":
+    set(value):
+        db_shape_glyph = value
+        if is_inside_tree():
+            _update_glyphs()
+
+@export var db_shape_color: Color = Color.WHITE:
+    set(value):
+        db_shape_color = value
+        if is_inside_tree():
+            _update_glyphs()
+
+@export var db_number_color: Color = Color.BLACK:
+    set(value):
+        db_number_color = value
+        if is_inside_tree():
+            _update_glyphs()
+
+@export var db_shape_font_size: int = 60:
+    set(value):
+        db_shape_font_size = value
+        if is_inside_tree():
+            _update_glyphs()
+
+@export var db_number_font_size: int = 32:
+    set(value):
+        db_number_font_size = value
+        if is_inside_tree():
+            _update_glyphs()
+
+var db_shape_label: Label
+var db_number_label: Label
+
+
+func _ready() -> void:
+    text = "D%d" % db_faces
+    add_theme_color_override("font_color", Color(0, 0, 0, 0))
+    db_shape_label = Label.new()
+    db_number_label = Label.new()
+    db_shape_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    db_shape_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+    db_shape_label.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
+    db_number_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    db_number_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+    db_number_label.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
+    add_child(db_shape_label)
+    add_child(db_number_label)
+    set_meta("faces", db_faces)
+    _update_glyphs()
+
+
+func _update_glyphs() -> void:
+    db_shape_label.text = db_shape_glyph
+    db_number_label.text = str(db_faces)
+    db_shape_label.add_theme_color_override("font_color", db_shape_color)
+    db_number_label.add_theme_color_override("font_color", db_number_color)
+    db_shape_label.add_theme_font_size_override("font_size", db_shape_font_size)
+    db_number_label.add_theme_font_size_override("font_size", db_number_font_size)

--- a/LIVEdie/scripts/quick_roll_bar.gd
+++ b/LIVEdie/scripts/quick_roll_bar.gd
@@ -70,14 +70,22 @@ func _ready() -> void:
 
 func _connect_dice_buttons(row: Container) -> void:
     for node in row.get_children():
-        if (
-            node is Button
-            and node.text.begins_with("D")
+        if not (node is Button):
+            continue
+        var faces := 0
+        var is_die := false
+        if node.has_meta("faces"):
+            faces = int(node.get_meta("faces"))
+            is_die = true
+        elif (
+            node.text.begins_with("D")
             and node.text != "DX?"
             and node.text != "ROLL"
             and node != $StandardRow/AdvancedToggle
         ):
-            var faces := int(node.text.substr(1).replace("%", "100"))
+            faces = int(node.text.substr(1).replace("%", "100"))
+            is_die = true
+        if is_die:
             node.button_down.connect(_on_die_down.bind(faces, node))
             node.button_up.connect(_on_die_up.bind(faces, node))
 


### PR DESCRIPTION
## Summary
- create `DieButton` script for shape and number overlay
- wire dice buttons in `quick_roll_bar.tscn` to use the new script
- detect die faces via metadata in `quick_roll_bar.gd`

## Testing
- `gdlint $(git diff --name-only -- '*.gd')`
- `godot --headless --editor --import --quit --path LIVEdie --quiet`
- `godot --headless --check-only --quit --path LIVEdie --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`
- `godot --headless --path LIVEdie -s res://tests/test_dice_parser.gd --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686dd28662508329892dc37d75e333b2