### PR TITLE
Add UIEventBus singleton

### DIFF
--- a/LIVEdie/GOGOT/project.godot
+++ b/LIVEdie/GOGOT/project.godot
@@ -2,3 +2,6 @@
 ; It's best edited using the Godot editor.
 
 config_version=5
+
+[autoload]
+UIEventBus="res://scripts/UIEventBus.gd"

--- a/LIVEdie/GOGOT/scripts/UIEventBus.gd
+++ b/LIVEdie/GOGOT/scripts/UIEventBus.gd
@@ -1,0 +1,14 @@
+# gdlint:disable=class-variable-name,function-name,class-definitions-order
+###############################################################
+# LIVEdie/GOGOT/scripts/UIEventBus.gd
+# Key Classes      • UIEventBus – central signal hub for UI events
+# Key Functions    • (none)
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • (none)
+# Last Major Rev   • 24-07-09 – initial placeholder
+###############################################################
+extends Node
+
+signal roll_requested
+signal system_selected(system_name)


### PR DESCRIPTION
## Summary
- plan for UI placeholder singletons from README
- add `UIEventBus.gd` script with placeholder signals
- register `UIEventBus` as autoload in Godot project
- fix autoload path
- add gdlint directive for stability

## Testing
- `gdlint LIVEdie/GOGOT/scripts/UIEventBus.gd`
- `godot --headless --editor --import --quit --path . --quiet` *(fails: no main scene)*
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_686e63d6b36883299cfc52686e5625c1