### PR TITLE
Add UI tab subscenes and docs

### DIFF
--- a/LIVEdie/GOGOT/scenes/HistoryTab.tscn
+++ b/LIVEdie/GOGOT/scenes/HistoryTab.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=1 format=3 uid="uid://historytab"]
+; HistoryTab – scrollable list of past rolls
+; Future: populate with roll summaries from log
+[node name="HistoryTab" type="ScrollContainer"]
+
+[node name="HistoryVBox" type="VBoxContainer" parent="."]
+; Each child will be a HistoryItem label

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=1 format=3 uid="uid://keyboardtab"]
+; KeyboardTab – custom dice input keyboard
+; Future: switch pages via swipe or toggle button
+[node name="KeyboardTab" type="StackContainer"]
+
+[node name="PageA" type="GridContainer" parent="."]
+; numeric / math page placeholder
+[node name="PageB" type="GridContainer" parent="."]
+; parser token page placeholder

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -1,4 +1,11 @@
-[gd_scene load_steps=1 format=3 uid="uid://mainui"]
+[gd_scene load_steps=7 format=3 uid="uid://mainui"]
+
+[ext_resource path="res://scenes/RollTab.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scenes/HistoryTab.tscn" type="PackedScene" id=2]
+[ext_resource path="res://scenes/SystemsTab.tscn" type="PackedScene" id=3]
+[ext_resource path="res://scenes/SettingsTab.tscn" type="PackedScene" id=4]
+[ext_resource path="res://scenes/KeyboardTab.tscn" type="PackedScene" id=5]
+[ext_resource path="res://scenes/QRTab.tscn" type="PackedScene" id=6]
 
 [node name="MainUI" type="Control"]
 anchor_right = 1.0
@@ -132,38 +139,16 @@ offset_top = -960
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="RollTab" type="Control" parent="LowerPane/TabHost"]
+[node name="RollTab" parent="LowerPane/TabHost" instance=ExtResource(1)]
 
-[node name="DiceArea" type="Node2D" parent="LowerPane/TabHost/RollTab"]
+[node name="HistoryTab" parent="LowerPane/TabHost" instance=ExtResource(2)]
 
-[node name="HistoryTab" type="ScrollContainer" parent="LowerPane/TabHost"]
+[node name="SystemsTab" parent="LowerPane/TabHost" instance=ExtResource(3)]
 
-[node name="HistoryVBox" type="VBoxContainer" parent="LowerPane/TabHost/HistoryTab"]
+[node name="SettingsTab" parent="LowerPane/TabHost" instance=ExtResource(4)]
 
-[node name="SystemsTab" type="ScrollContainer" parent="LowerPane/TabHost"]
+[node name="KeyboardTab" parent="LowerPane/TabHost" instance=ExtResource(5)]
 
-[node name="SystemVBox" type="VBoxContainer" parent="LowerPane/TabHost/SystemsTab"]
+[node name="QRTab" parent="LowerPane/TabHost" instance=ExtResource(6)]
 
-[node name="SettingsTab" type="VBoxContainer" parent="LowerPane/TabHost"]
-
-[node name="ThemeColor" type="ColorPickerButton" parent="LowerPane/TabHost/SettingsTab"]
-
-[node name="FontScaleSlider" type="HSlider" parent="LowerPane/TabHost/SettingsTab"]
-
-[node name="AnimLevelOption" type="OptionButton" parent="LowerPane/TabHost/SettingsTab"]
-
-[node name="SettingsSpacer" type="Control" parent="LowerPane/TabHost/SettingsTab"]
-size_flags_vertical = 3
-
-[node name="KeyboardTab" type="StackContainer" parent="LowerPane/TabHost"]
-
-[node name="PageA" type="GridContainer" parent="LowerPane/TabHost/KeyboardTab"]
-
-[node name="PageB" type="GridContainer" parent="LowerPane/TabHost/KeyboardTab"]
-
-[node name="QRTab" type="Control" parent="LowerPane/TabHost"]
-
-[node name="QRCode" type="TextureRect" parent="LowerPane/TabHost/QRTab"]
-anchor_right = 1.0
-anchor_bottom = 1.0
 

--- a/LIVEdie/GOGOT/scenes/QRTab.tscn
+++ b/LIVEdie/GOGOT/scenes/QRTab.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=1 format=3 uid="uid://qrtab"]
+; QRTab – placeholder for QR code connection
+; Next step: generate code from session info
+[node name="QRTab" type="Control"]
+
+[node name="QRCode" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0

--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=1 format=3 uid="uid://rolltab"]
+; RollTab – hosts dice animations and result display
+; Next: connect to UIEventBus roll_requested to trigger animation
+[node name="RollTab" type="Control"]
+
+[node name="DiceArea" type="Node2D" parent="."]
+; Placeholder Node2D for future 2D/3D dice sprites

--- a/LIVEdie/GOGOT/scenes/SettingsTab.tscn
+++ b/LIVEdie/GOGOT/scenes/SettingsTab.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=1 format=3 uid="uid://settingstab"]
+; SettingsTab – UI preferences
+; Next: hook controls to config storage
+[node name="SettingsTab" type="VBoxContainer"]
+
+[node name="ThemeColor" type="ColorPickerButton" parent="."]
+[node name="FontScaleSlider" type="HSlider" parent="."]
+[node name="AnimLevelOption" type="OptionButton" parent="."]
+[node name="SettingsSpacer" type="Control" parent="."]
+size_flags_vertical = 3

--- a/LIVEdie/GOGOT/scenes/SystemsTab.tscn
+++ b/LIVEdie/GOGOT/scenes/SystemsTab.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=1 format=3 uid="uid://systemstab"]
+; SystemsTab – choose rulesets, star favorites
+; TODO: connect selection to UIEventBus system_selected
+[node name="SystemsTab" type="ScrollContainer"]
+
+[node name="SystemVBox" type="VBoxContainer" parent="."]
+; Placeholder buttons with star checkboxes

--- a/LIVEdie/TODO.md
+++ b/LIVEdie/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- Implement DrawerController animations.
+- Add 2D/3D dice physics for RollTab.
+- Wire system selection logic through UIEventBus.

--- a/LIVEdie/readme.md
+++ b/LIVEdie/readme.md
@@ -137,3 +137,15 @@ QRTab (Control)
 ---
 
 **End Blueprint**
+
+## Running the Project
+
+1. Open Godot in `LIVEdie/GOGOT/`:
+
+   ```bash
+   godot --editor LIVEdie/GOGOT
+   ```
+
+2. Set `res://scenes/MainUI.tscn` as the main scene or run it directly from the editor.
+
+This repository contains only layout scaffolding and placeholder scripts. Gameplay and dice logic are planned for future updates.


### PR DESCRIPTION
## Summary
- split each tab of the dice roller into its own scene
- reference these scenes from `MainUI.tscn`
- document how to run the project and add TODO list for future work

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --editor --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: project assets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9c1b65088329a8b871c1eed2b37a