### PR TITLE
Add centered dice pad rows

### DIFF
--- a/LIVEdie/GOGOT/project.godot
+++ b/LIVEdie/GOGOT/project.godot
@@ -10,6 +10,9 @@ config_version=5
 
 [application]
 
+config/name="LIVEdie"
+config/description="LIVEdie
+DieCAST"
 run/main_scene="uid://mainui"
 config/features=PackedStringArray("4.4")
 

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://keyboardtab"]
 
-[node name="KeyboardTab" type="StackContainer"]
+[node name="KeyboardTab" type="Control"]
 _import_path = NodePath("")
 unique_name_in_owner = false
 process_mode = 0

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -1,17 +1,12 @@
 [gd_scene format=3 uid="uid://keyboardtab"]
 
 [node name="KeyboardTab" type="Control"]
-_import_path = NodePath("")
-unique_name_in_owner = false
-process_mode = 0
-process_priority = 0
-process_physics_priority = 0
-process_thread_group = 0
 physics_interpolation_mode = 0
-auto_translate_mode = 0
-editor_description = ""
-script = null
+layout_mode = 3
+anchors_preset = 0
 
 [node name="PageA" type="GridContainer" parent="."]
+layout_mode = 0
 
 [node name="PageB" type="GridContainer" parent="."]
+layout_mode = 0

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -42,12 +42,18 @@ layout_mode = 2
 custom_minimum_size = Vector2(0, 700)
 layout_mode = 0
 anchor_right = 1.0
-anchor_bottom = 1.0
+anchor_bottom = 0.0
 offset_top = 120.0
-offset_bottom = -960.0
+offset_bottom = 0.0
+size_flags_horizontal = 1
+size_flags_vertical = 4
 
 [node name="QtyRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
+separation = 12
+
+[node name="QtyLeftSpacer" type="Control" parent="DicePad/QtyRow"]
+size_flags_horizontal = 2
 
 [node name="Qty1" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
@@ -79,8 +85,15 @@ custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 text = "10×"
 
+[node name="QtyRightSpacer" type="Control" parent="DicePad/QtyRow"]
+size_flags_horizontal = 2
+
 [node name="CommonDiceRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
+separation = 12
+
+[node name="DiceLeftSpacer" type="Control" parent="DicePad/CommonDiceRow"]
+size_flags_horizontal = 2
 
 [node name="D4" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
@@ -111,6 +124,9 @@ text = "D12"
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 text = "D20"
+
+[node name="DiceRightSpacer" type="Control" parent="DicePad/CommonDiceRow"]
+size_flags_horizontal = 2
 
 [node name="AdvancedRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -13,6 +13,8 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="TopBar" type="PanelContainer" parent="."]
 layout_mode = 0
@@ -42,17 +44,14 @@ layout_mode = 2
 custom_minimum_size = Vector2(0, 700)
 layout_mode = 0
 anchor_right = 1.0
-anchor_bottom = 0.0
 offset_top = 120.0
-offset_bottom = 0.0
-size_flags_horizontal = 1
 size_flags_vertical = 4
 
 [node name="QtyRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
-separation = 12
 
 [node name="QtyLeftSpacer" type="Control" parent="DicePad/QtyRow"]
+layout_mode = 2
 size_flags_horizontal = 2
 
 [node name="Qty1" type="Button" parent="DicePad/QtyRow"]
@@ -86,13 +85,14 @@ layout_mode = 2
 text = "10×"
 
 [node name="QtyRightSpacer" type="Control" parent="DicePad/QtyRow"]
+layout_mode = 2
 size_flags_horizontal = 2
 
 [node name="CommonDiceRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
-separation = 12
 
 [node name="DiceLeftSpacer" type="Control" parent="DicePad/CommonDiceRow"]
+layout_mode = 2
 size_flags_horizontal = 2
 
 [node name="D4" type="Button" parent="DicePad/CommonDiceRow"]
@@ -126,6 +126,7 @@ layout_mode = 2
 text = "D20"
 
 [node name="DiceRightSpacer" type="Control" parent="DicePad/CommonDiceRow"]
+layout_mode = 2
 size_flags_horizontal = 2
 
 [node name="AdvancedRow" type="HBoxContainer" parent="DicePad"]
@@ -200,18 +201,11 @@ layout_mode = 2
 metadata/_tab_index = 3
 
 [node name="KeyboardTab" parent="LowerPane/TabHost" instance=ExtResource("5")]
-_import_path = NodePath("")
-unique_name_in_owner = false
-process_mode = 0
-process_priority = 0
-process_physics_priority = 0
-process_thread_group = 0
-physics_interpolation_mode = 0
-auto_translate_mode = 0
-editor_description = ""
-script = null
+visible = false
+layout_mode = 2
+metadata/_tab_index = 4
 
 [node name="QRTab" parent="LowerPane/TabHost" instance=ExtResource("6")]
 visible = false
 layout_mode = 2
-metadata/_tab_index = 4
+metadata/_tab_index = 5


### PR DESCRIPTION
## Summary
- anchor DicePad to top and center it with size flags
- center quantity buttons and common dice using spacer Controls
- fix project compatibility by switching KeyboardTab root to Control

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: project assets not restored)*

------
https://chatgpt.com/codex/tasks/task_e_686ff295152883299345d54def10ffaf