### PR TITLE
Add advanced dice pad UI and logic

### DIFF
--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://settingstab" path="res://scenes/SettingsTab.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://keyboardtab" path="res://scenes/KeyboardTab.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://qrtab" path="res://scenes/QRTab.tscn" id="6"]
+[ext_resource type="Script" path="res://scripts/DicePad.gd" id="7"]
 
 [node name="MainUI" type="Control"]
 custom_minimum_size = Vector2(1080, 1920)
@@ -46,9 +47,11 @@ layout_mode = 0
 anchor_right = 1.0
 offset_top = 120.0
 size_flags_vertical = 4
+script = ExtResource("7")
 
 [node name="QtyRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
+separation = 12
 
 [node name="QtyLeftSpacer" type="Control" parent="DicePad/QtyRow"]
 layout_mode = 2
@@ -90,6 +93,7 @@ size_flags_horizontal = 2
 
 [node name="CommonDiceRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
+separation = 12
 
 [node name="DiceLeftSpacer" type="Control" parent="DicePad/CommonDiceRow"]
 layout_mode = 2
@@ -131,6 +135,11 @@ size_flags_horizontal = 2
 
 [node name="AdvancedRow" type="HBoxContainer" parent="DicePad"]
 layout_mode = 2
+separation = 12
+
+[node name="AdvancedLeftSpacer" type="Control" parent="DicePad/AdvancedRow"]
+layout_mode = 2
+size_flags_horizontal = 2
 
 [node name="D2Btn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
@@ -162,13 +171,21 @@ custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 text = "⌫"
 
+[node name="AdvancedRightSpacer" type="Control" parent="DicePad/AdvancedRow"]
+layout_mode = 2
+size_flags_horizontal = 2
+
 [node name="SystemDropdown" type="Button" parent="DicePad"]
 custom_minimum_size = Vector2(48, 48)
 layout_mode = 2
+text = "▼"
+size_flags_horizontal = 4
 
 [node name="QueueLabel" type="Label" parent="DicePad"]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
+text = "(no dice)"
+autowrap_mode = 1
 
 [node name="LowerPane" type="PanelContainer" parent="."]
 layout_mode = 0

--- a/LIVEdie/GOGOT/scripts/DicePad.gd
+++ b/LIVEdie/GOGOT/scripts/DicePad.gd
@@ -1,0 +1,117 @@
+# gdlint:disable=class-variable-name,function-name,class-definitions-order
+###############################################################
+# LIVEdie/GOGOT/scripts/DicePad.gd
+# Key Classes      • DicePad – manages dice input state and queue
+# Key Functions    • _on_Quantity_pressed, _on_Die_pressed
+# Critical Consts  • DP_LONG_PRESS_TIME
+# Editor Exports   • (none)
+# Dependencies     • UIEventBus.gd
+# Last Major Rev   • 24-07-10 – initial implementation
+###############################################################
+class_name DicePad
+extends VBoxContainer
+
+const DP_LONG_PRESS_TIME: float = 0.5
+
+@onready var DP_queue_label_SH: Label = $QueueLabel
+var DP_current_quantity_SH: int = 1
+var DP_backspace_timer_IN: Timer
+var DP_backspace_long_SH: bool = false
+
+
+func _ready() -> void:
+    DP_backspace_timer_IN = Timer.new()
+    DP_backspace_timer_IN.one_shot = true
+    DP_backspace_timer_IN.wait_time = DP_LONG_PRESS_TIME
+    DP_backspace_timer_IN.timeout.connect(_on_Backspace_long)
+    add_child(DP_backspace_timer_IN)
+
+    _connect_quantity_buttons()
+    _connect_die_buttons()
+    $AdvancedRow/DXPromptBtn.pressed.connect(_on_CustomDie_pressed)
+    $AdvancedRow/PipeBtn.pressed.connect(_on_Pipe_pressed)
+    $AdvancedRow/BackspaceBtn.pressed.connect(_on_Backspace_pressed)
+    $AdvancedRow/BackspaceBtn.gui_input.connect(_on_Backspace_gui_input)
+    $AdvancedRow/RollBtn.pressed.connect(_on_Roll_pressed)
+
+
+func _connect_quantity_buttons() -> void:
+    var map := {
+        $QtyRow/Qty1: 1,
+        $QtyRow/Qty2: 2,
+        $QtyRow/Qty3: 3,
+        $QtyRow/Qty4: 4,
+        $QtyRow/Qty5: 5,
+        $QtyRow/Qty10: 10
+    }
+    for btn in map.keys():
+        btn.pressed.connect(_on_Quantity_pressed.bind(map[btn]))
+
+
+func _connect_die_buttons() -> void:
+    var die_map := {
+        $CommonDiceRow/D4: 4,
+        $CommonDiceRow/D6: 6,
+        $CommonDiceRow/D8: 8,
+        $CommonDiceRow/D10: 10,
+        $CommonDiceRow/D12: 12,
+        $CommonDiceRow/D20: 20,
+        $AdvancedRow/D2Btn: 2,
+        $AdvancedRow/D100Btn: 100
+    }
+    for btn in die_map.keys():
+        btn.pressed.connect(_on_Die_pressed.bind(die_map[btn]))
+
+
+func _on_Quantity_pressed(value: int) -> void:
+    DP_current_quantity_SH = value
+
+
+func _on_Die_pressed(faces: int) -> void:
+    var prefix := str(DP_current_quantity_SH) + "×D" + str(faces)
+    if DP_queue_label_SH.text == "(no dice)" or DP_queue_label_SH.text == "":
+        DP_queue_label_SH.text = prefix
+    else:
+        DP_queue_label_SH.text += ", " + prefix
+    DP_current_quantity_SH = 1
+
+
+func _on_CustomDie_pressed() -> void:
+    if DP_queue_label_SH.text == "(no dice)" or DP_queue_label_SH.text == "":
+        DP_queue_label_SH.text = "DX?"
+    else:
+        DP_queue_label_SH.text += ", DX?"
+
+
+func _on_Pipe_pressed() -> void:
+    DP_queue_label_SH.text += " | "
+
+
+func _on_Backspace_gui_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.pressed:
+        DP_backspace_timer_IN.start()
+    elif event is InputEventMouseButton and not event.pressed:
+        if DP_backspace_timer_IN.is_stopped():
+            return
+        DP_backspace_timer_IN.stop()
+        if DP_backspace_long_SH:
+            DP_backspace_long_SH = false
+
+
+func _on_Backspace_long() -> void:
+    DP_backspace_long_SH = true
+    DP_queue_label_SH.text = ""
+
+
+func _on_Backspace_pressed() -> void:
+    if DP_backspace_long_SH:
+        DP_backspace_long_SH = false
+        return
+    if DP_queue_label_SH.text.length() > 0:
+        DP_queue_label_SH.text = DP_queue_label_SH.text.substr(
+            0, DP_queue_label_SH.text.length() - 1
+        )
+
+
+func _on_Roll_pressed() -> void:
+    print(DP_queue_label_SH.text)


### PR DESCRIPTION
## Summary
- add advanced row and queue label in `MainUI.tscn`
- implement `DicePad.gd` for quantity, die and roll logic

## Testing
- `gdlint LIVEdie/GOGOT/scripts/DicePad.gd`
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo` *(fails: assets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffadff71c8329b18a6cb3026e0f09