### PR TITLE
Add placeholder labels and titles for lower pane tabs

### DIFF
--- a/LIVEdie/GOGOT/project.godot
+++ b/LIVEdie/GOGOT/project.godot
@@ -24,6 +24,8 @@ UIEventBus="res://scripts/UIEventBus.gd"
 
 window/size/viewport_width=1080
 window/size/viewport_height=1920
+window/size/window_width_override=1080
+window/size/window_height_override=1920
 window/stretch/mode="viewport"
 window/handheld/orientation=1
 

--- a/LIVEdie/GOGOT/scenes/HistoryTab.tscn
+++ b/LIVEdie/GOGOT/scenes/HistoryTab.tscn
@@ -5,3 +5,6 @@
 
 [node name="HistoryVBox" type="VBoxContainer" parent="."]
 ; Each child will be a HistoryItem label
+
+[node name="HistoryPlaceholder" type="Label" parent="HistoryVBox"]
+text = "(History list placeholder)"

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -7,10 +7,14 @@ anchors_preset = 0
 
 [node name="PageA" type="GridContainer" parent="."]
 layout_mode = 0
+
 [node name="LabelA" type="Label" parent="PageA"]
+layout_mode = 2
 text = "Numeric Page (A)"
 
 [node name="PageB" type="GridContainer" parent="."]
 layout_mode = 0
+
 [node name="LabelB" type="Label" parent="PageB"]
+layout_mode = 2
 text = "Notation Page (B)"

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -7,6 +7,10 @@ anchors_preset = 0
 
 [node name="PageA" type="GridContainer" parent="."]
 layout_mode = 0
+[node name="LabelA" type="Label" parent="PageA"]
+text = "Numeric Page (A)"
 
 [node name="PageB" type="GridContainer" parent="."]
 layout_mode = 0
+[node name="LabelB" type="Label" parent="PageB"]
+text = "Notation Page (B)"

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -194,32 +194,42 @@ offset_top = -960.0
 [node name="TabHost" type="TabContainer" parent="LowerPane"]
 layout_mode = 2
 current_tab = 0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 
 [node name="RollTab" parent="LowerPane/TabHost" instance=ExtResource("1")]
 layout_mode = 2
+tab_title = "Roll"
 metadata/_tab_index = 0
 
 [node name="HistoryTab" parent="LowerPane/TabHost" instance=ExtResource("2")]
 visible = false
 layout_mode = 2
+tab_title = "History"
 metadata/_tab_index = 1
 
 [node name="SystemsTab" parent="LowerPane/TabHost" instance=ExtResource("3")]
 visible = false
 layout_mode = 2
+tab_title = "Systems"
 metadata/_tab_index = 2
 
 [node name="SettingsTab" parent="LowerPane/TabHost" instance=ExtResource("4")]
 visible = false
 layout_mode = 2
+tab_title = "Settings"
 metadata/_tab_index = 3
 
 [node name="KeyboardTab" parent="LowerPane/TabHost" instance=ExtResource("5")]
 visible = false
 layout_mode = 2
+tab_title = "Keyboard"
 metadata/_tab_index = 4
 
 [node name="QRTab" parent="LowerPane/TabHost" instance=ExtResource("6")]
 visible = false
 layout_mode = 2
+tab_title = "QR"
 metadata/_tab_index = 5

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -194,42 +194,32 @@ offset_top = -960.0
 [node name="TabHost" type="TabContainer" parent="LowerPane"]
 layout_mode = 2
 current_tab = 0
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 1.0
-anchor_bottom = 1.0
 
 [node name="RollTab" parent="LowerPane/TabHost" instance=ExtResource("1")]
 layout_mode = 2
-tab_title = "Roll"
 metadata/_tab_index = 0
 
 [node name="HistoryTab" parent="LowerPane/TabHost" instance=ExtResource("2")]
 visible = false
 layout_mode = 2
-tab_title = "History"
 metadata/_tab_index = 1
 
 [node name="SystemsTab" parent="LowerPane/TabHost" instance=ExtResource("3")]
 visible = false
 layout_mode = 2
-tab_title = "Systems"
 metadata/_tab_index = 2
 
 [node name="SettingsTab" parent="LowerPane/TabHost" instance=ExtResource("4")]
 visible = false
 layout_mode = 2
-tab_title = "Settings"
 metadata/_tab_index = 3
 
 [node name="KeyboardTab" parent="LowerPane/TabHost" instance=ExtResource("5")]
 visible = false
 layout_mode = 2
-tab_title = "Keyboard"
 metadata/_tab_index = 4
 
 [node name="QRTab" parent="LowerPane/TabHost" instance=ExtResource("6")]
 visible = false
 layout_mode = 2
-tab_title = "QR"
 metadata/_tab_index = 5

--- a/LIVEdie/GOGOT/scenes/QRTab.tscn
+++ b/LIVEdie/GOGOT/scenes/QRTab.tscn
@@ -6,3 +6,5 @@
 [node name="QRCode" type="TextureRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+[node name="PlaceholderLabel" type="Label" parent="."]
+text = "(QR code placeholder)"

--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -5,3 +5,6 @@
 
 [node name="DiceArea" type="Node2D" parent="."]
 ; Placeholder Node2D for future 2D/3D dice sprites
+
+[node name="PlaceholderLabel" type="Label" parent="."]
+text = "Roll View (animation)"

--- a/LIVEdie/GOGOT/scenes/SettingsTab.tscn
+++ b/LIVEdie/GOGOT/scenes/SettingsTab.tscn
@@ -4,6 +4,8 @@
 [node name="SettingsTab" type="VBoxContainer"]
 
 [node name="ThemeColor" type="ColorPickerButton" parent="."]
+[node name="PlaceholderLabel" type="Label" parent="."]
+text = "(Settings placeholder)"
 [node name="FontScaleSlider" type="HSlider" parent="."]
 [node name="AnimLevelOption" type="OptionButton" parent="."]
 [node name="SettingsSpacer" type="Control" parent="."]

--- a/LIVEdie/GOGOT/scenes/SystemsTab.tscn
+++ b/LIVEdie/GOGOT/scenes/SystemsTab.tscn
@@ -5,3 +5,6 @@
 
 [node name="SystemVBox" type="VBoxContainer" parent="."]
 ; Placeholder buttons with star checkboxes
+
+[node name="SystemsPlaceholder" type="Label" parent="SystemVBox"]
+text = "(Systems list placeholder)"


### PR DESCRIPTION
## Summary
- add placeholder labels within tab scenes
- set tab titles in `MainUI` and adjust anchors

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project found)*

------
https://chatgpt.com/codex/tasks/task_e_68700272f6888329a08c0b1cf934b863