### PR TITLE
Fix dice roll wiring

### DIFF
--- a/LIVEdie/GOGOT/scenes/HistoryTab.tscn
+++ b/LIVEdie/GOGOT/scenes/HistoryTab.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=1 format=3 uid="uid://historytab"]
+[gd_scene load_steps=2 format=3 uid="uid://historytab"]
+
+[ext_resource type="Script" path="res://scripts/HistoryTab.gd" id="1"]
 ; HistoryTab – scrollable list of past rolls
 ; Future: populate with roll summaries from log
 [node name="HistoryTab" type="ScrollContainer"]
 
 [node name="HistoryVBox" type="VBoxContainer" parent="."]
+script = ExtResource("1")
 ; Each child will be a HistoryItem label
 
 [node name="HistoryPlaceholder" type="Label" parent="HistoryVBox"]

--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=1 format=3 uid="uid://rolltab"]
+[gd_scene load_steps=2 format=3 uid="uid://rolltab"]
+
+[ext_resource type="Script" path="res://scripts/RollTab.gd" id="1"]
 ; RollTab – hosts dice animations and result display
 ; Next: connect to UIEventBus roll_requested to trigger animation
 [node name="RollTab" type="Control"]
+script = ExtResource("1")
 
 [node name="DiceArea" type="Node2D" parent="."]
 ; Placeholder Node2D for future 2D/3D dice sprites

--- a/LIVEdie/GOGOT/scripts/DicePad.gd
+++ b/LIVEdie/GOGOT/scripts/DicePad.gd
@@ -114,4 +114,5 @@ func _on_Backspace_pressed() -> void:
 
 
 func _on_Roll_pressed() -> void:
-    get_node("/root/UIEventBus").emit_signal("roll_requested", DP_queue_label_SH.text)
+    var clean := DP_queue_label_SH.text.replace("×", "").replace("D", "d")
+    get_node("/root/UIEventBus").emit_signal("roll_requested", clean)

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -1,0 +1,21 @@
+###############################################################
+# LIVEdie/GOGOT/scripts/HistoryTab.gd
+# Key Classes      • HistoryTab – records executed rolls
+# Key Functions    • _on_roll_executed
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • RollExecutor.gd
+# Last Major Rev   • 24-07-11 – initial stub
+###############################################################
+class_name HistoryTab
+extends VBoxContainer
+
+
+func _ready() -> void:
+    get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
+
+
+func _on_roll_executed(result: Dictionary) -> void:
+    var entry := Label.new()
+    entry.text = "%sd → %s" % [result.notation, result.total]
+    add_child(entry)

--- a/LIVEdie/GOGOT/scripts/RollExecutor.gd
+++ b/LIVEdie/GOGOT/scripts/RollExecutor.gd
@@ -14,6 +14,7 @@ extends Node
 signal roll_executed(result: Dictionary)
 
 var RE_parser_IN: DiceParser
+var RE_last_result_SH: Dictionary = {}
 
 
 func _ready() -> void:
@@ -22,6 +23,7 @@ func _ready() -> void:
 
 
 func _on_roll_requested(notation: String) -> void:
+    print("\u25B6 RollExecutor got:", notation)
     var plan := RE_parser_IN.DP_parse_expression(notation)
     var groups: Array = []
     for g in plan.dice_groups:
@@ -29,14 +31,14 @@ func _on_roll_requested(notation: String) -> void:
         g["result"] = res
         groups.append(res)
     var result := RE_eval_ast_IN(plan.ast)
-    var payload := {
+    RE_last_result_SH = {
         "notation": notation,
         "total": result.value,
         "rolls": result.rolls,
         "kept": result.kept,
         "groups": groups,
     }
-    roll_executed.emit(payload)
+    roll_executed.emit(RE_last_result_SH)
 
 
 func RE_eval_ast_IN(node: Variant) -> Dictionary:

--- a/LIVEdie/GOGOT/scripts/RollTab.gd
+++ b/LIVEdie/GOGOT/scripts/RollTab.gd
@@ -1,0 +1,19 @@
+###############################################################
+# LIVEdie/GOGOT/scripts/RollTab.gd
+# Key Classes      • RollTab – handles roll animation placeholder
+# Key Functions    • _on_roll_executed
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • UIEventBus.gd
+# Last Major Rev   • 24-07-11 – initial stub
+###############################################################
+class_name RollTab
+extends Control
+
+
+func _ready() -> void:
+    get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
+
+
+func _on_roll_executed(result: Dictionary) -> void:
+    print("Result:", result)

--- a/LIVEdie/GOGOT/scripts/UIEventBus.gd
+++ b/LIVEdie/GOGOT/scripts/UIEventBus.gd
@@ -10,5 +10,5 @@
 ###############################################################
 extends Node
 
-signal roll_requested
+signal roll_requested(notation: String)
 signal system_selected(system_name)

--- a/LIVEdie/GOGOT/tests/test_roll.gd
+++ b/LIVEdie/GOGOT/tests/test_roll.gd
@@ -1,0 +1,19 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var bus = preload("res://scripts/UIEventBus.gd").new()
+    bus.name = "UIEventBus"
+    var rng = RNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(bus)
+    root.add_child(rng)
+    root.add_child(exec)
+    bus.roll_requested.connect(exec._on_roll_requested)
+    bus.roll_requested.emit("1d4")
+    assert(exec.RE_last_result_SH.notation == "1d4")
+    print("RollExecutor test passed")
+    quit()


### PR DESCRIPTION
## Summary
- send notation through `roll_requested` signal
- sanitize notation in DicePad
- log result in RollExecutor and expose last result
- display roll info in RollTab and HistoryTab
- add a small RollExecutor test

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68708f0e0e948329b5d12960f76b6334