### PR TITLE
Support comma/pipe separated dice groups

### DIFF
--- a/LIVEdie/GOGOT/scripts/RollExecutor.gd
+++ b/LIVEdie/GOGOT/scripts/RollExecutor.gd
@@ -30,12 +30,19 @@ func _on_roll_requested(notation: String) -> void:
         var res := RE_roll_group_IN(g)
         g["result"] = res
         groups.append(res)
-    var result := RE_eval_ast_IN(plan.ast)
+    var total := 0
+    var rolls: Array = []
+    var kept: Array = []
+    for ast in plan.asts:
+        var res := RE_eval_ast_IN(ast)
+        total += res.value
+        rolls += res.rolls
+        kept += res.kept
     RE_last_result_SH = {
         "notation": notation,
-        "total": result.value,
-        "rolls": result.rolls,
-        "kept": result.kept,
+        "total": total,
+        "rolls": rolls,
+        "kept": kept,
         "groups": groups,
     }
     roll_executed.emit(RE_last_result_SH)

--- a/LIVEdie/GOGOT/tests/test_dice_parser.gd
+++ b/LIVEdie/GOGOT/tests/test_dice_parser.gd
@@ -9,7 +9,8 @@ func _init() -> void:
     assert(g.num == 4 and g.sides == 6)
     assert(g.mods.size() == 1)
     assert(g.mods[0].type == "kh" and g.mods[0].count == 3)
-    assert(plan.ast.type == "binary")
+    assert(plan.asts.size() == 1)
+    assert(plan.asts[0].type == "binary")
     assert(plan.constants.has(2))
 
     var plan2 := parser.DP_parse_expression("2d20adv")
@@ -32,7 +33,19 @@ func _init() -> void:
     var plan5 := parser.DP_parse_expression("3d6+2*5")
     assert(plan5.dice_groups.size() == 1)
     assert(plan5.constants.size() == 2)
-    assert(plan5.ast.right.op == "*")
+    assert(plan5.asts[0].right.op == "*")
+
+    var plan6 := parser.DP_parse_expression("3d6,5d12")
+    assert(plan6.asts.size() == 2)
+    assert(plan6.dice_groups.size() == 2)
+    assert(plan6.dice_groups[0].num == 3)
+    assert(plan6.dice_groups[1].num == 5)
+
+    var plan7 := parser.DP_parse_expression("2d8 | 1d4")
+    assert(plan7.asts.size() == 2)
+    assert(plan7.dice_groups.size() == 2)
+    assert(plan7.dice_groups[0].sides == 8)
+    assert(plan7.dice_groups[1].sides == 4)
 
     print("All DiceParser tests passed")
     quit()

--- a/LIVEdie/GOGOT/tests/test_roll.gd
+++ b/LIVEdie/GOGOT/tests/test_roll.gd
@@ -15,5 +15,8 @@ func _init() -> void:
     bus.roll_requested.connect(exec._on_roll_requested)
     bus.roll_requested.emit("1d4")
     assert(exec.RE_last_result_SH.notation == "1d4")
+
+    bus.roll_requested.emit("1d4,2d6")
+    assert(exec.RE_last_result_SH.groups.size() == 2)
     print("RollExecutor test passed")
     quit()


### PR DESCRIPTION
## Summary
- expand token regex for comma/pipe
- parse multiple groups separated by these tokens
- handle multi‑group rolls in `RollExecutor`
- test new parser behavior and rolling logic

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo`
- `godot --headless -s res://tests/test_dice_parser.gd --quit --path LIVEdie/GOGOT`
- `godot --headless -s res://tests/test_roll.gd --quit --path LIVEdie/GOGOT` *(fails: Node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a1de9e488329adb5f75965c1ac4c