### PR TITLE
Handle invalid dice notation errors

### DIFF
--- a/LIVEdie/GOGOT/scripts/DicePad.gd
+++ b/LIVEdie/GOGOT/scripts/DicePad.gd
@@ -33,6 +33,7 @@ func _ready() -> void:
     $AdvancedRow/BackspaceBtn.pressed.connect(_on_Backspace_pressed)
     $AdvancedRow/BackspaceBtn.gui_input.connect(_on_Backspace_gui_input)
     $AdvancedRow/RollBtn.pressed.connect(_on_Roll_pressed)
+    get_node("/root/RollExecutor").roll_failed.connect(_on_roll_failed)
 
 
 func _connect_quantity_buttons() -> void:
@@ -116,3 +117,9 @@ func _on_Backspace_pressed() -> void:
 func _on_Roll_pressed() -> void:
     var clean := DP_queue_label_SH.text.replace("×", "").replace("D", "d")
     get_node("/root/UIEventBus").emit_signal("roll_requested", clean)
+
+
+func _on_roll_failed(msg: String) -> void:
+    DP_queue_label_SH.modulate = Color(1, 0.2, 0.2)
+    push_warning(msg)
+    create_tween().tween_property(DP_queue_label_SH, "modulate", Color(1, 1, 1), 0.4)

--- a/LIVEdie/GOGOT/scripts/RollExecutor.gd
+++ b/LIVEdie/GOGOT/scripts/RollExecutor.gd
@@ -12,6 +12,7 @@ class_name RollExecutor
 extends Node
 
 signal roll_executed(result: Dictionary)
+signal roll_failed(message: String)
 
 var RE_parser_IN: DiceParser
 var RE_last_result_SH: Dictionary = {}
@@ -25,6 +26,10 @@ func _ready() -> void:
 func _on_roll_requested(notation: String) -> void:
     print("\u25B6 RollExecutor got:", notation)
     var plan := RE_parser_IN.DP_parse_expression(notation)
+    if plan.errors.size() > 0:
+        RE_last_result_SH = {}
+        roll_failed.emit(" ".join(plan.errors.map(func(e): return e.msg)))
+        return
     var groups: Array = []
     for g in plan.dice_groups:
         var res := RE_roll_group_IN(g)

--- a/LIVEdie/GOGOT/tests/test_invalid_notation.gd
+++ b/LIVEdie/GOGOT/tests/test_invalid_notation.gd
@@ -1,0 +1,35 @@
+extends SceneTree
+
+var cases = [
+    {"src": "3d", "expect_msg": "missing sides"},
+    {"src": "5d10,", "expect_msg": "Unexpected input"},
+    {"src": ",2d6", "expect_msg": "Unexpected input"},
+    {"src": "2d6 |", "expect_msg": "Unexpected input"},
+    {"src": "1d8, 1d8 , 4d1 , 1d", "expect_msg": "missing sides"}
+]
+
+
+func _init() -> void:
+    var bus = preload("res://scripts/UIEventBus.gd").new()
+    bus.name = "UIEventBus"
+    var rng = RNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(bus)
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+
+    var got: Array = []
+    exec.roll_failed.connect(func(msg): got.append(msg))
+
+    for case in cases:
+        bus.roll_requested.emit(case.src)
+        assert(exec.RE_last_result_SH.is_empty())
+        var msg = got.pop_back()
+        assert(msg.find(case.expect_msg) != -1)
+
+    print("Invalid notation tests passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_roll.gd
+++ b/LIVEdie/GOGOT/tests/test_roll.gd
@@ -12,7 +12,7 @@ func _init() -> void:
     root.add_child(bus)
     root.add_child(rng)
     root.add_child(exec)
-    bus.roll_requested.connect(exec._on_roll_requested)
+    await process_frame
     bus.roll_requested.emit("1d4")
     assert(exec.RE_last_result_SH.notation == "1d4")
 


### PR DESCRIPTION
## Summary
- surface parse errors in DiceParser
- stop execution when notation fails to parse
- show roll failures in DicePad UI
- add regression tests for invalid notation
- update existing roll test to await scene readiness

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_dice_parser.gd --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_roll.gd --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_invalid_notation.gd --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project found)*

------
https://chatgpt.com/codex/tasks/task_e_6870cd397ea48329890d0ad7caf73a13