### PR TITLE
Fix pipe queue insertion logic

### DIFF
--- a/LIVEdie/GOGOT/scripts/DicePad.gd
+++ b/LIVEdie/GOGOT/scripts/DicePad.gd
@@ -70,10 +70,15 @@ func _on_Quantity_pressed(value: int) -> void:
 
 func _on_Die_pressed(faces: int) -> void:
     var prefix := str(DP_current_quantity_SH) + "×D" + str(faces)
-    if DP_queue_label_SH.text == "(no dice)" or DP_queue_label_SH.text == "":
+    var base := DP_queue_label_SH.text
+    while base.ends_with(" ") or base.ends_with(","):
+        base = base.substr(0, base.length() - 1)
+    if base == "(no dice)" or base == "":
         DP_queue_label_SH.text = prefix
+    elif base.ends_with("|"):
+        DP_queue_label_SH.text = base + " " + prefix
     else:
-        DP_queue_label_SH.text += ", " + prefix
+        DP_queue_label_SH.text = base + ", " + prefix
     DP_current_quantity_SH = 1
 
 
@@ -85,7 +90,11 @@ func _on_CustomDie_pressed() -> void:
 
 
 func _on_Pipe_pressed() -> void:
-    DP_queue_label_SH.text += " | "
+    var base := DP_queue_label_SH.text
+    while base.ends_with(" ") or base.ends_with(","):
+        base = base.substr(0, base.length() - 1)
+    base = base.strip_edges(false, true)
+    DP_queue_label_SH.text = base + " | "
 
 
 func _on_Backspace_gui_input(event: InputEvent) -> void:

--- a/LIVEdie/GOGOT/tests/test_dicepad_queue.gd
+++ b/LIVEdie/GOGOT/tests/test_dicepad_queue.gd
@@ -1,0 +1,27 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var bus = preload("res://scripts/UIEventBus.gd").new()
+    bus.name = "UIEventBus"
+    var rng = RNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(bus)
+    root.add_child(rng)
+    root.add_child(exec)
+    var scene = load("res://scenes/MainUI.tscn")
+    var main = scene.instantiate()
+    root.add_child(main)
+    await process_frame
+    var dp = main.get_node("DicePad")
+    dp._on_Die_pressed(6)
+    dp._on_Pipe_pressed()
+    dp._on_Die_pressed(8)
+    dp._on_Pipe_pressed()
+    dp._on_Die_pressed(8)
+    assert(dp.DP_queue_label_SH.text == "1×D6 | 1×D8 | 1×D8")
+    print("DicePad queue test passed")
+    quit()


### PR DESCRIPTION
## Summary
- sanitize `DicePad` pipe/quantity handling
- trim dangling commas before inserting pipe
- add `test_dicepad_queue.gd` covering pipe button order

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --nologo` *(SoftBodyFish.sln)*
- `godot --headless --path . -s res://tests/test_roll.gd`
- `godot --headless --path . -s res://tests/test_dice_parser.gd`
- `godot --headless --path . -s res://tests/test_invalid_notation.gd`
- `godot --headless --path . -s res://tests/test_pipe_notation.gd`
- `godot --headless --path . -s res://tests/test_dicepad_queue.gd`


------
https://chatgpt.com/codex/tasks/task_e_6870ed807dd08329bdebb270513322da