### PR TITLE
Fix pipe guard and history breakdown

### DIFF
--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -17,8 +17,11 @@ func _ready() -> void:
 
 func _on_roll_executed(result: Dictionary) -> void:
     var entry := Label.new()
-    var totals := []
+    var parts := []
     for sec in result.sections:
-        totals.append(str(sec.value))
-    entry.text = "%sd → %s" % [result.notation, " | ".join(totals)]
+        if sec.rolls.size() > 1:
+            parts.append(sec.rolls.map(func(r): return str(r)).join(" + "))
+        else:
+            parts.append(str(sec.value))
+    entry.text = "%s → %s" % [result.notation, " | ".join(parts)]
     add_child(entry)

--- a/LIVEdie/GOGOT/tests/test_double_pipe.gd
+++ b/LIVEdie/GOGOT/tests/test_double_pipe.gd
@@ -1,0 +1,29 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var bus = preload("res://scripts/UIEventBus.gd").new()
+    bus.name = "UIEventBus"
+    var rng = RNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(bus)
+    root.add_child(rng)
+    root.add_child(exec)
+    var scene = load("res://scenes/MainUI.tscn")
+    var main = scene.instantiate()
+    root.add_child(main)
+    await process_frame
+    var dp = main.get_node("DicePad")
+    dp._on_Die_pressed(6)
+    dp._on_Pipe_pressed()
+    dp._on_Pipe_pressed()
+    assert(dp.DP_queue_label_SH.text == "1×D6 | ")
+    assert(dp.get_node("AdvancedRow/RollBtn").disabled)
+    dp._on_Die_pressed(8)
+    assert(dp.DP_queue_label_SH.text == "1×D6 | 1×D8")
+    assert(not dp.get_node("AdvancedRow/RollBtn").disabled)
+    print("Double pipe test passed")
+    quit()


### PR DESCRIPTION
## Summary
- prevent double pipes and trailing pipes
- collapse spaces in queue label
- richer HistoryTab output
- add double pipe unit test

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `godot --headless -s res://tests/test_double_pipe.gd`
- `for t in tests/test_*.gd; do echo "Running $t"; godot --headless -s res://$t >/tmp/test.log && tail -n 1 /tmp/test.log; done`

------
https://chatgpt.com/codex/tasks/task_e_68712798843083298f1db5a95810116d