### PR TITLE
Implement double pipe guard and history detail

### DIFF
--- a/LIVEdie/GOGOT/scripts/DicePad.gd
+++ b/LIVEdie/GOGOT/scripts/DicePad.gd
@@ -14,6 +14,7 @@ extends VBoxContainer
 const DP_LONG_PRESS_TIME: float = 0.5
 
 @onready var DP_queue_label_SH: Label = $QueueLabel
+@onready var DP_roll_btn_SH: Button = $AdvancedRow/RollBtn
 var DP_current_quantity_SH: int = 1
 var DP_backspace_timer_IN: Timer
 var DP_backspace_long_SH: bool = false
@@ -34,6 +35,18 @@ func _ready() -> void:
     $AdvancedRow/BackspaceBtn.gui_input.connect(_on_Backspace_gui_input)
     $AdvancedRow/RollBtn.pressed.connect(_on_Roll_pressed)
     get_node("/root/RollExecutor").roll_failed.connect(_on_roll_failed)
+
+    _update_roll_btn_state()
+
+    if has_node("CustomDieDialog"):
+        var custom_dialog: AcceptDialog = $CustomDieDialog
+        custom_dialog.canceled.connect(
+            func():
+                DP_queue_label_SH.text = DP_queue_label_SH.text.replace(", DX?", "").replace(
+                    "DX?", ""
+                )
+                _collapse_spaces()
+        )
 
 
 func _connect_quantity_buttons() -> void:
@@ -80,6 +93,8 @@ func _on_Die_pressed(faces: int) -> void:
     else:
         DP_queue_label_SH.text = base + ", " + prefix
     DP_current_quantity_SH = 1
+    _collapse_spaces()
+    _update_roll_btn_state()
 
 
 func _on_CustomDie_pressed() -> void:
@@ -87,14 +102,19 @@ func _on_CustomDie_pressed() -> void:
         DP_queue_label_SH.text = "DX?"
     else:
         DP_queue_label_SH.text += ", DX?"
+    _update_roll_btn_state()
 
 
 func _on_Pipe_pressed() -> void:
-    var base := DP_queue_label_SH.text
-    while base.ends_with(" ") or base.ends_with(","):
-        base = base.substr(0, base.length() - 1)
-    base = base.strip_edges(false, true)
-    DP_queue_label_SH.text = base + " | "
+    var t := DP_queue_label_SH.text.rstrip(" ,").strip_edges(false, true)
+
+    if t == "" or t.ends_with("|"):
+        _update_roll_btn_state()
+        return
+
+    DP_queue_label_SH.text = t + " | "
+    _collapse_spaces()
+    _update_roll_btn_state()
 
 
 func _on_Backspace_gui_input(event: InputEvent) -> void:
@@ -111,6 +131,7 @@ func _on_Backspace_gui_input(event: InputEvent) -> void:
 func _on_Backspace_long() -> void:
     DP_backspace_long_SH = true
     DP_queue_label_SH.text = ""
+    _update_roll_btn_state()
 
 
 func _on_Backspace_pressed() -> void:
@@ -129,6 +150,8 @@ func _on_Backspace_pressed() -> void:
             DP_queue_label_SH.text = DP_queue_label_SH.text.substr(
                 0, DP_queue_label_SH.text.length() - 1
             )
+    _collapse_spaces()
+    _update_roll_btn_state()
 
 
 func _on_Roll_pressed() -> void:
@@ -140,3 +163,13 @@ func _on_roll_failed(msg: String) -> void:
     DP_queue_label_SH.modulate = Color(1, 0.2, 0.2)
     push_warning(msg)
     create_tween().tween_property(DP_queue_label_SH, "modulate", Color(1, 1, 1), 0.4)
+
+
+func _collapse_spaces() -> void:
+    var re := RegEx.new()
+    re.compile("\\s+")
+    DP_queue_label_SH.text = re.sub(DP_queue_label_SH.text, " ")
+
+
+func _update_roll_btn_state() -> void:
+    DP_roll_btn_SH.disabled = DP_queue_label_SH.text.strip_edges(false, true).ends_with("|")

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -17,8 +17,11 @@ func _ready() -> void:
 
 func _on_roll_executed(result: Dictionary) -> void:
     var entry := Label.new()
-    var totals := []
+    var parts := []
     for sec in result.sections:
-        totals.append(str(sec.value))
-    entry.text = "%sd → %s" % [result.notation, " | ".join(totals)]
+        if sec.rolls.size() > 1:
+            parts.append(sec.rolls.map(func(r): return str(r)).join(" + "))
+        else:
+            parts.append(str(sec.value))
+    entry.text = "%s → %s" % [result.notation, " | ".join(parts)]
     add_child(entry)

--- a/LIVEdie/GOGOT/tests/test_double_pipe.gd
+++ b/LIVEdie/GOGOT/tests/test_double_pipe.gd
@@ -1,0 +1,30 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var bus = preload("res://scripts/UIEventBus.gd").new()
+    bus.name = "UIEventBus"
+    var rng = RNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(bus)
+    root.add_child(rng)
+    root.add_child(exec)
+    var scene = load("res://scenes/MainUI.tscn")
+    var main = scene.instantiate()
+    root.add_child(main)
+    await process_frame
+
+    var dp = main.get_node("DicePad")
+    dp._on_Die_pressed(6)
+    dp._on_Pipe_pressed()
+    dp._on_Pipe_pressed()
+    assert(dp.DP_queue_label_SH.text == "1×D6 | ")
+    var roll_btn = main.get_node("DicePad/AdvancedRow/RollBtn")
+    assert(roll_btn.disabled)
+    dp._on_Die_pressed(4)
+    assert(not roll_btn.disabled)
+    print("Double pipe test passed")
+    quit()


### PR DESCRIPTION
## Summary
- prevent double pipes and trailing pipes in DicePad
- collapse spaces helper and update Roll button disabled state
- clean up custom die text on dialog cancel
- expand HistoryTab breakdown per section
- add regression test for double pipe input

## Testing
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build --no-restore --nologo` *(fails: project or solution file not found)*
- `godot --headless -s res://tests/test_double_pipe.gd --quit --path . --verbose`
- `godot --headless -s res://tests/test_dicepad_queue.gd --quit --path . --quiet`
- `godot --headless -s res://tests/test_pipe_notation.gd --quit --path . --quiet`
- `godot --headless -s res://tests/test_roll.gd --quit --path . --quiet`
- `godot --headless -s res://tests/test_dice_parser.gd --quit --path . --quiet`
- `godot --headless -s res://tests/test_invalid_notation.gd --quit --path . --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68712798843083298f1db5a95810116d