### PR TITLE
Fix history join crash

### DIFF
--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -17,8 +17,11 @@ func _ready() -> void:
 
 func _on_roll_executed(result: Dictionary) -> void:
     var entry := Label.new()
-    var totals := []
+    var parts := []
     for sec in result.sections:
-        totals.append(str(sec.value))
-    entry.text = "%sd → %s" % [result.notation, " | ".join(totals)]
+        if sec.rolls.size() > 1:
+            parts.append(" + ".join(sec.rolls.map(func(r): return str(r))))
+        else:
+            parts.append(str(sec.value))
+    entry.text = "%s → %s" % [result.notation, " | ".join(parts)]
     add_child(entry)

--- a/LIVEdie/GOGOT/tests/test_double_pipe.gd
+++ b/LIVEdie/GOGOT/tests/test_double_pipe.gd
@@ -1,0 +1,29 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var bus = preload("res://scripts/UIEventBus.gd").new()
+    bus.name = "UIEventBus"
+    var rng = RNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(bus)
+    root.add_child(rng)
+    root.add_child(exec)
+    var scene = load("res://scenes/MainUI.tscn")
+    var main = scene.instantiate()
+    root.add_child(main)
+    await process_frame
+    var dp = main.get_node("DicePad")
+    dp._on_Die_pressed(6)
+    dp._on_Pipe_pressed()
+    dp._on_Pipe_pressed()
+    assert(dp.DP_queue_label_SH.text == "1×D6 | ")
+    assert(dp.get_node("AdvancedRow/RollBtn").disabled)
+    dp._on_Die_pressed(8)
+    assert(dp.DP_queue_label_SH.text == "1×D6 | 1×D8")
+    assert(not dp.get_node("AdvancedRow/RollBtn").disabled)
+    print("Double pipe test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_history_join.gd
+++ b/LIVEdie/GOGOT/tests/test_history_join.gd
@@ -1,0 +1,12 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var ht: HistoryTab = preload("res://scripts/HistoryTab.gd").new()
+    root.add_child(ht)
+    var dummy := {"notation": "3d6", "sections": [{"rolls": [4, 2, 6], "value": 12}]}
+    ht._on_roll_executed(dummy)
+    assert(ht.get_child_count() == 1)
+    assert(ht.get_child(0).text.ends_with("4 + 2 + 6"))
+    print("History join test passed")
+    quit()


### PR DESCRIPTION
## Summary
- safeguard HistoryTab: use String.join for multi-die sections
- add unit test validating history output

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-cache`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`
- `for t in LIVEdie/GOGOT/tests/test_*.gd; do godot --headless -s res://tests/$(basename $t) --path LIVEdie/GOGOT >/tmp/test.log && tail -n 1 /tmp/test.log; done`


------
https://chatgpt.com/codex/tasks/task_e_68712798843083298f1db5a95810116d