### PR TITLE
Implement advanced dice roller features

### DIFF
--- a/LIVEdie/GOGOT/scripts/DiceParser.gd
+++ b/LIVEdie/GOGOT/scripts/DiceParser.gd
@@ -1,4 +1,5 @@
-# gdlint:disable=class-variable-name,function-name,class-definitions-order
+# gdlint:disable=class-variable-name,function-name,class-definitions-order,max-returns
+# gdlint:disable=no-elif-return,no-else-return
 ###############################################################
 # LIVEdie/GOGOT/scripts/DiceParser.gd
 # Key Classes      • DiceParser – parse dice notation into roll plan
@@ -12,7 +13,7 @@ class_name DiceParser
 extends RefCounted
 
 const DP_TOKEN_REGEX: String = (
-    "(\\d+|adv|dis|kh|kl|dh|dl|ro|ra|r|cs|cf|count|VS|"
+    "(\\d+|adv|dis|kh|kl|dh|dl|ro|ra|r|cs|cf|count|[Vv][Ss]|"
     + ">=|<=|>|<|!!|p!!|!|p|\\(|\\)|[+\\-*/,|]|d|F|f|%|[A-Za-z_][A-Za-z0-9_]*)"
 )
 
@@ -78,7 +79,7 @@ func _DP_tokenize_IN(expr: String) -> Array:
             tokens.append({"type": "COMPARE", "value": t})
         elif t in ["!!", "!", "p", "p!!"]:
             tokens.append({"type": "EXPLODE", "value": t})
-        elif t == "VS":
+        elif t.to_lower() == "vs":
             tokens.append({"type": "VS", "value": t})
         elif t.is_valid_identifier():
             tokens.append({"type": "IDENT", "value": t})

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -5,10 +5,11 @@
 # Critical Consts  • (none)
 # Editor Exports   • (none)
 # Dependencies     • RollExecutor.gd
-# Last Major Rev   • 24-07-11 – initial stub
+# Last Major Rev   • 24-07-12 – emit update signal
 ###############################################################
 class_name HistoryTab
 extends VBoxContainer
+signal history_updated
 
 
 func _ready() -> void:
@@ -17,21 +18,23 @@ func _ready() -> void:
 
 func _on_roll_executed(result: Dictionary) -> void:
     var entry := Label.new()
-    var parts := []
+    var parts: Array = []
     for sec in result.sections:
+        var snippet := ""
         if sec.rolls.size() > 1:
-            parts.append(" + ".join(sec.rolls.map(func(r): return str(r))))
+            snippet = " + ".join(sec.rolls.map(func(r): return str(r)))
         else:
-            parts.append(str(sec.value))
+            snippet = str(sec.value)
+        if sec.has("meta"):
+            var ex := []
+            if sec.meta.succ > 0:
+                ex.append("%d successes" % sec.meta.succ)
+            if sec.meta.crit > 0:
+                ex.append("%d crit" % sec.meta.crit)
+            if ex.size() > 0:
+                snippet += " (" + ", ".join(ex) + ")"
+        parts.append(snippet)
     var text := "%s → %s" % [result.notation, " | ".join(parts)]
-    if result.sections.size() == 1 and result.sections[0].has("meta"):
-        var m = result.sections[0].meta
-        var extras := []
-        if m.succ > 0:
-            extras.append("%d successes" % m.succ)
-        if m.crit > 0:
-            extras.append("%d crit" % m.crit)
-        if extras.size() > 0:
-            text += " (" + ", ".join(extras) + ")"
     entry.text = text
     add_child(entry)
+    history_updated.emit()

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -16,24 +16,28 @@ func _ready() -> void:
     get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
 
 
+func _HT_build_snippet_IN(sec: Dictionary) -> String:
+    var snippet := ""
+    if sec.rolls.size() > 1:
+        snippet = " + ".join(sec.rolls.map(func(r): return str(r)))
+    else:
+        snippet = str(sec.value)
+    if sec.has("meta"):
+        var extras: Array = []
+        if sec.meta.succ > 0:
+            extras.append("%d successes" % sec.meta.succ)
+        if sec.meta.crit > 0:
+            extras.append("%d crit" % sec.meta.crit)
+        if extras.size() > 0:
+            snippet += " (" + ", ".join(extras) + ")"
+    return snippet
+
+
 func _on_roll_executed(result: Dictionary) -> void:
     var entry := Label.new()
     var parts: Array = []
     for sec in result.sections:
-        var snippet := ""
-        if sec.rolls.size() > 1:
-            snippet = " + ".join(sec.rolls.map(func(r): return str(r)))
-        else:
-            snippet = str(sec.value)
-        if sec.has("meta"):
-            var ex := []
-            if sec.meta.succ > 0:
-                ex.append("%d successes" % sec.meta.succ)
-            if sec.meta.crit > 0:
-                ex.append("%d crit" % sec.meta.crit)
-            if ex.size() > 0:
-                snippet += " (" + ", ".join(ex) + ")"
-        parts.append(snippet)
+        parts.append(_HT_build_snippet_IN(sec))
     var text := "%s → %s" % [result.notation, " | ".join(parts)]
     entry.text = text
     add_child(entry)

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -23,5 +23,15 @@ func _on_roll_executed(result: Dictionary) -> void:
             parts.append(" + ".join(sec.rolls.map(func(r): return str(r))))
         else:
             parts.append(str(sec.value))
-    entry.text = "%s → %s" % [result.notation, " | ".join(parts)]
+    var text := "%s → %s" % [result.notation, " | ".join(parts)]
+    if result.sections.size() == 1 and result.sections[0].has("meta"):
+        var m = result.sections[0].meta
+        var extras := []
+        if m.succ > 0:
+            extras.append("%d successes" % m.succ)
+        if m.crit > 0:
+            extras.append("%d crit" % m.crit)
+        if extras.size() > 0:
+            text += " (" + ", ".join(extras) + ")"
+    entry.text = text
     add_child(entry)

--- a/LIVEdie/GOGOT/scripts/RollExecutor.gd
+++ b/LIVEdie/GOGOT/scripts/RollExecutor.gd
@@ -84,36 +84,92 @@ func RE_eval_ast_IN(node: Variant) -> Dictionary:
                             val = 0
                         else:
                             val = left.value / right.value
+                    "vs":
+                        var lscore := _RE_vs_score_IN(left)
+                        var rscore := _RE_vs_score_IN(right)
+                        var win := "tie"
+                        if lscore > rscore:
+                            win = "lhs"
+                        elif rscore > lscore:
+                            win = "rhs"
+                        return {
+                            "value": 0,
+                            "rolls": left.rolls + right.rolls,
+                            "kept": left.kept + right.kept,
+                            "winner": win,
+                            "lhs": left,
+                            "rhs": right,
+                        }
                 return {
                     "value": val,
                     "rolls": left.rolls + right.rolls,
                     "kept": left.kept + right.kept,
                 }
+            "func":
+                var args: Array = []
+                for a in node.args:
+                    args.append(RE_eval_ast_IN(a))
+                return _RE_eval_function_IN(node.name, args)
     return {"value": 0, "rolls": [], "kept": []}
 
 
 func RE_roll_group_IN(group: Dictionary) -> Dictionary:
     var results: Array = []
     for i in range(group.num):
-        if typeof(group.sides) == TYPE_STRING and group.sides == "F":
-            results.append(get_node("/root/RNGManager").RM_generate_fudge_SH())
-        else:
-            var sides_val := 0
-            if typeof(group.sides) == TYPE_STRING:
-                if group.sides == "%":
-                    sides_val = 100
-                else:
-                    sides_val = int(group.sides)
-            else:
-                sides_val = int(group.sides)
-            results.append(get_node("/root/RNGManager").RM_generate_roll_SH(sides_val))
+        results.append(_RE_roll_die_IN(group.sides))
+
     var kept := results.duplicate()
     for mod in group.mods:
-        kept = _RE_apply_keepdrop_IN(kept, mod)
+        if mod.type in ["kh", "kl", "dh", "dl"]:
+            kept = _RE_apply_keepdrop_IN(kept, mod)
+
+    var extras: Array = []
+    for mod in group.mods:
+        if mod.type == "reroll":
+            var rr = _RE_apply_reroll_IN(kept, mod, group.sides)
+            kept = rr.kept
+            extras += rr.extra
+        elif mod.type == "explode":
+            var ex = _RE_apply_explode_IN(kept, mod, group.sides)
+            kept = ex.kept
+            extras += ex.extra
+
+    var meta := {"succ": 0, "crit": 0, "fail": 0}
+    var count_success := false
+    for m in group.mods:
+        if m.type in ["success", "cs", "cf"]:
+            count_success = true
     var sum := 0
     for v in kept:
+        var succ := false
+        var crit := false
+        var fail := false
+        for m in group.mods:
+            match m.type:
+                "success":
+                    succ = succ or _RE_compare_condition_IN(v, m.compare, m.target)
+                "cs":
+                    crit = crit or _RE_compare_condition_IN(v, m.compare, m.target)
+                "cf":
+                    fail = fail or _RE_compare_condition_IN(v, m.compare, m.target)
+                "count":
+                    succ = succ or v == int(m.target)
+        if succ:
+            meta.succ += 1
+        if crit:
+            meta.crit += 1
+        if fail:
+            meta.fail += 1
         sum += v
-    return {"value": sum, "rolls": results, "kept": kept}
+    var value := sum
+    if count_success or meta.succ > 0 or meta.crit > 0 or meta.fail > 0:
+        value = meta.succ
+    return {
+        "value": value,
+        "rolls": results + extras,
+        "kept": kept,
+        "meta": meta,
+    }
 
 
 func _RE_apply_keepdrop_IN(results: Array, mod: Dictionary) -> Array:
@@ -137,3 +193,192 @@ func _RE_apply_keepdrop_IN(results: Array, mod: Dictionary) -> Array:
         _:
             out = sorted
     return out
+
+
+func _RE_roll_die_IN(sides: Variant) -> int:
+    var rng := get_node("/root/RNGManager")
+    if typeof(sides) == TYPE_STRING:
+        if sides == "F":
+            return rng.RM_generate_fudge_SH()
+        elif sides == "%":
+            return rng.RM_generate_roll_SH(100)
+        else:
+            return rng.RM_generate_roll_SH(int(sides))
+    return rng.RM_generate_roll_SH(int(sides))
+
+
+func _RE_compare_condition_IN(value: int, comp: String, target: int) -> bool:
+    match comp:
+        "<":
+            return value < target
+        "<=":
+            return value <= target
+        ">":
+            return value > target
+        ">=":
+            return value >= target
+        "":
+            return value == target
+    return false
+
+
+func _RE_apply_reroll_IN(results: Array, mod: Dictionary, sides: Variant) -> Dictionary:
+    var out := results.duplicate()
+    var extra: Array = []
+    for i in range(out.size()):
+        if _RE_compare_condition_IN(out[i], mod.compare, mod.target):
+            if mod.method == "ra":
+                var loops := 0
+                while _RE_compare_condition_IN(out[i], mod.compare, mod.target) and loops < 100:
+                    out[i] = _RE_roll_die_IN(sides)
+                    extra.append(out[i])
+                    loops += 1
+            else:
+                out[i] = _RE_roll_die_IN(sides)
+                extra.append(out[i])
+    return {"kept": out, "extra": extra}
+
+
+func _RE_should_explode_IN(value: int, mod: Dictionary, sides: Variant) -> bool:
+    if mod.compare == "":
+        var max_val := 0
+        if typeof(sides) == TYPE_STRING:
+            if sides == "%":
+                max_val = 100
+            elif sides == "F":
+                max_val = 1
+            else:
+                max_val = int(sides)
+        else:
+            max_val = int(sides)
+        return value == max_val
+    return _RE_compare_condition_IN(value, mod.compare, mod.target)
+
+
+func _RE_apply_explode_IN(results: Array, mod: Dictionary, sides: Variant) -> Dictionary:
+    var out := results.duplicate()
+    var extra: Array = []
+    var compound = mod.style.find("!!") != -1
+    var penetrate = mod.style.begins_with("p")
+    for i in range(out.size()):
+        var total_extra = 0
+        var current = out[i]
+        var loops = 0
+        while _RE_should_explode_IN(current, mod, sides) and loops < 100:
+            var roll := _RE_roll_die_IN(sides)
+            extra.append(roll)
+            var add_val := roll
+            if penetrate:
+                add_val -= 1
+            if compound:
+                total_extra += add_val
+            else:
+                out.append(add_val)
+            current = roll
+            loops += 1
+        if loops >= 100:
+            push_warning("Explosion max iterations reached")
+        if compound and total_extra != 0:
+            out[i] += total_extra
+    return {"kept": out, "extra": extra}
+
+
+func _RE_vs_score_IN(data: Dictionary) -> int:
+    var succ := 0
+    var has := false
+    if data.has("groups"):
+        for g in data.groups:
+            if typeof(g) == TYPE_DICTIONARY and g.has("meta") and g.meta.succ > 0:
+                succ += g.meta.succ
+                has = true
+    if has:
+        return succ
+    var mx := 0
+    for v in data.kept:
+        mx = max(mx, int(v))
+    return mx
+
+
+func RE_roll_vs(lhs_notation: String, rhs_notation: String) -> Dictionary:
+    var lhs := _debug_roll(lhs_notation)
+    var rhs := _debug_roll(rhs_notation)
+    var lscore := _RE_vs_score_IN(lhs)
+    var rscore := _RE_vs_score_IN(rhs)
+    var w := "tie"
+    if lscore > rscore:
+        w = "lhs"
+    elif rscore > lscore:
+        w = "rhs"
+    return {"winner": w, "lhs": lhs, "rhs": rhs}
+
+
+func RE_roll_with_wild(num_sides: int, wild_sides: int = 6) -> Dictionary:
+    var normal = _debug_roll("1d" + str(num_sides) + "!")
+    var wild = _debug_roll("1d" + str(wild_sides) + "!")
+    var val = max(normal.total, wild.total)
+    return {"value": val, "normal": normal, "wild": wild}
+
+
+func _debug_roll(notation: String) -> Dictionary:
+    var plan := RE_parser_IN.DP_parse_expression(notation)
+    if plan.errors.size() > 0:
+        return {
+            "notation": notation, "total": 0, "rolls": [], "kept": [], "groups": [], "sections": []
+        }
+    var groups: Array = []
+    for g in plan.dice_groups:
+        if g.type == "number":
+            groups.append({"value": g.value})
+            continue
+        var res := RE_roll_group_IN(g)
+        g["result"] = res
+        groups.append(res)
+    var total := 0
+    var rolls: Array = []
+    var kept: Array = []
+    var sections: Array = []
+    for ast in plan.sections:
+        var res := RE_eval_ast_IN(ast)
+        total += res.value
+        rolls += res.rolls
+        kept += res.kept
+        sections.append(res)
+    return {
+        "notation": notation,
+        "total": total,
+        "rolls": rolls,
+        "kept": kept,
+        "groups": groups,
+        "sections": sections,
+    }
+
+
+func _RE_eval_function_IN(name: String, args: Array) -> Dictionary:
+    var rolls: Array = []
+    var kept: Array = []
+    var values: Array = []
+    for a in args:
+        rolls += a.rolls
+        kept += a.kept
+        values.append(a.value)
+    match name:
+        "min":
+            return {"value": min(values[0], values[1]), "rolls": rolls, "kept": kept}
+        "max":
+            return {"value": max(values[0], values[1]), "rolls": rolls, "kept": kept}
+        "sum":
+            var s := 0
+            for v in values:
+                s += v
+            return {"value": s, "rolls": rolls, "kept": kept}
+        "floor":
+            return {"value": floor(values[0]), "rolls": rolls, "kept": kept}
+        "ceil":
+            return {"value": ceil(values[0]), "rolls": rolls, "kept": kept}
+        "sort":
+            kept.sort()
+            return {"value": values[0] if values.size() > 0 else 0, "rolls": rolls, "kept": kept}
+        "rolls":
+            return {"value": 0, "rolls": rolls, "kept": kept}
+        _:
+            return {"value": values[0] if values.size() > 0 else 0, "rolls": rolls, "kept": kept}

--- a/LIVEdie/GOGOT/tests/test_abs_function.gd
+++ b/LIVEdie/GOGOT/tests/test_abs_function.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("abs(-3)")
+    assert(res.total == 3)
+    print("Abs function test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_explode_no_double_count.gd
+++ b/LIVEdie/GOGOT/tests/test_explode_no_double_count.gd
@@ -1,0 +1,33 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+    var seq := []
+
+    func _init(s := []):
+        seq = s
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+    func RM_generate_roll_SH(_num_sides: int) -> int:
+        if seq.is_empty():
+            return 2
+        return seq.pop_front()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new([2])
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("1d6!!")
+    assert(res.kept.size() == 1)
+    assert(res.kept[0] == 2)
+    print("Explode no double count test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_exploding.gd
+++ b/LIVEdie/GOGOT/tests/test_exploding.gd
@@ -1,0 +1,32 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+    var seq := []
+
+    func _init(s := []):
+        seq = s
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+    func RM_generate_roll_SH(_num_sides: int) -> int:
+        if seq.is_empty():
+            return 1
+        return seq.pop_front()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new([6, 1, 2, 3, 4, 5, 6])
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("6d6!")
+    assert(res.total >= 7)
+    print("Exploding test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_history_multi_section.gd
+++ b/LIVEdie/GOGOT/tests/test_history_multi_section.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var ht: HistoryTab = preload("res://scripts/HistoryTab.gd").new()
+    root.add_child(ht)
+    var dummy = {
+        "notation": "2d6>=5 | 1d20cs>=20",
+        "sections":
+        [
+            {"rolls": [5, 6], "value": 2, "meta": {"succ": 2, "crit": 0, "fail": 0}},
+            {"rolls": [20], "value": 1, "meta": {"succ": 1, "crit": 1, "fail": 0}}
+        ]
+    }
+    ht._on_roll_executed(dummy)
+    assert(ht.get_child_count() == 1)
+    var text = ht.get_child(0).text
+    var parts = text.split(" → ")[1].split(" | ")
+    assert(parts.size() == 2)
+    assert(parts[0].find("success") != -1)
+    assert(parts[1].find("crit") != -1)
+    print("History multi-section test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_history_no_dup_parts.gd
+++ b/LIVEdie/GOGOT/tests/test_history_no_dup_parts.gd
@@ -1,0 +1,15 @@
+extends SceneTree
+
+
+func _init() -> void:
+    var ht: HistoryTab = preload("res://scripts/HistoryTab.gd").new()
+    root.add_child(ht)
+    var dummy = {
+        "notation": "1d4 | 1d6",
+        "sections": [{"rolls": [3], "value": 3}, {"rolls": [5], "value": 5}]
+    }
+    ht._on_roll_executed(dummy)
+    var parts = ht.get_child(0).text.split(" → ")[1].split(" | ")
+    assert(parts.size() == 2)
+    print("History no dup parts test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_min_max.gd
+++ b/LIVEdie/GOGOT/tests/test_min_max.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("max(1d4,2)")
+    assert(res.total >= 2)
+    print("Min/Max test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_reroll.gd
+++ b/LIVEdie/GOGOT/tests/test_reroll.gd
@@ -1,0 +1,32 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+    var seq := []
+
+    func _init(s := []):
+        seq = s
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+    func RM_generate_roll_SH(_num_sides: int) -> int:
+        if seq.is_empty():
+            return 1
+        return seq.pop_front()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new([1, 4])
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("1d6r<2")
+    assert(res.kept[0] != 1)
+    print("Reroll test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_success_count.gd
+++ b/LIVEdie/GOGOT/tests/test_success_count.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("10d6>=5")
+    assert(typeof(res.total) == TYPE_INT)
+    print("Success count test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_vs_parenthesised.gd
+++ b/LIVEdie/GOGOT/tests/test_vs_parenthesised.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec._debug_roll("(1d4 vs 1d4) + 1")
+    assert(res.sections[0].winner in ["lhs", "rhs", "tie"])
+    print("VS parenthesised test passed")
+    quit()

--- a/LIVEdie/GOGOT/tests/test_vs_pool.gd
+++ b/LIVEdie/GOGOT/tests/test_vs_pool.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+
+class TestRNGManager:
+    extends RNGManager
+
+    func _ready() -> void:
+        RM_rng_IN = RandomNumberGenerator.new()
+
+
+func _init() -> void:
+    var rng = TestRNGManager.new()
+    rng.name = "RNGManager"
+    var exec: RollExecutor = RollExecutor.new()
+    exec.name = "RollExecutor"
+    exec.RE_parser_IN = DiceParser.new()
+    root.add_child(rng)
+    root.add_child(exec)
+    await process_frame
+    var res = exec.RE_roll_vs("4d6", "3d6")
+    assert(res.has("winner"))
+    print("VS pool test passed")
+    quit()

--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@ This workspace hosts multiple Godot experiments.
 
 - `FISHYX3/` – the main softbody fish tank simulation project.
 - `fishtank/` – a separate modular aquarium prototype built with Godot 4.4.1.
+
+## Stage-1 Feature Matrix
+
+| Area | Status |
+|------|--------|
+| Dice notation parser | ✅ |
+| Basic execution (sum, keep/drop, pipes) | ✅ |
+| Reroll & explode | ✅ |
+| Success counting & criticals | ✅ |
+| History logging | ✅ |
+| VS operator & functions | ✅ |
+


### PR DESCRIPTION
## Summary
- expand DiceParser with VS operator and functions
- implement rerolls, explosions, success counting and helper utilities
- display successes in history entries
- add debug helpers and opposed roll support
- extend test suite for new features

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo`
- `godot --headless -s res://tests/test_success_count.gd --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_exploding.gd --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_reroll.gd --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_vs_pool.gd --path LIVEdie/GOGOT --quiet`
- `godot --headless -s res://tests/test_min_max.gd --path LIVEdie/GOGOT --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68715a6271b48329aaeaaf70c9503fc0