### PR TITLE
Implement dice roll animation

### DIFF
--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -6,8 +6,12 @@
 [node name="RollTab" type="Control"]
 script = ExtResource("1")
 
-[node name="DiceArea" type="Node2D" parent="."]
-; Placeholder Node2D for future 2D/3D dice sprites
+[node name="DiceArea" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+anchor_left = 0.0
+anchor_top = 0.0
+; Placeholder Control for future dice sprites
 
 [node name="PlaceholderLabel" type="Label" parent="."]
 text = "Roll View (animation)"

--- a/LIVEdie/GOGOT/scripts/RollTab.gd
+++ b/LIVEdie/GOGOT/scripts/RollTab.gd
@@ -5,15 +5,38 @@
 # Critical Consts  • (none)
 # Editor Exports   • (none)
 # Dependencies     • UIEventBus.gd
-# Last Major Rev   • 24-07-11 – initial stub
+# Last Major Rev   • 24-07-15 – add placeholder dice animation
 ###############################################################
 class_name RollTab
 extends Control
 
+@onready var RT_dice_area_SH: Node = $DiceArea
+var RT_rng_IN: RandomNumberGenerator
+
 
 func _ready() -> void:
+    RT_rng_IN = RandomNumberGenerator.new()
+    RT_rng_IN.randomize()
     get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
+
+
+func RT_play_basic_animation_IN() -> void:
+    var sz := size
+    for i in range(3):
+        var lbl := Label.new()
+        lbl.text = str(RT_rng_IN.randi_range(1, 6))
+        lbl.modulate.a = 0.0
+        lbl.position = Vector2(
+            RT_rng_IN.randi_range(0, int(sz.x)), RT_rng_IN.randi_range(0, int(sz.y))
+        )
+        RT_dice_area_SH.add_child(lbl)
+        var tw := create_tween()
+        tw.tween_property(lbl, "modulate:a", 1.0, 0.15)
+        tw.tween_interval(0.15)
+        tw.tween_property(lbl, "modulate:a", 0.0, 0.15)
+        tw.tween_callback(Callable(lbl, "queue_free"))
 
 
 func _on_roll_executed(result: Dictionary) -> void:
     print("Result:", result)
+    RT_play_basic_animation_IN()


### PR DESCRIPTION
## Summary
- add animated placeholder dice roll labels
- connect RollTab to RollExecutor and play animation on roll
- ensure DiceArea covers full tab

## Testing
- `bash LIVEdie/fix_indent.sh LIVEdie/GOGOT/scripts/RollTab.gd`
- `gdlint LIVEdie/GOGOT/scripts/RollTab.gd`
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68719dd4dc6483299fd0f35d8119ae1f