### PR TITLE
Implement RollTab dice animation

### DIFF
--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -6,8 +6,12 @@
 [node name="RollTab" type="Control"]
 script = ExtResource("1")
 
-[node name="DiceArea" type="Node2D" parent="."]
-; Placeholder Node2D for future 2D/3D dice sprites
+[node name="DiceArea" type="Control" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+; Placeholder Control for future 2D/3D dice sprites
 
 [node name="PlaceholderLabel" type="Label" parent="."]
 text = "Roll View (animation)"

--- a/LIVEdie/GOGOT/scripts/RollTab.gd
+++ b/LIVEdie/GOGOT/scripts/RollTab.gd
@@ -10,10 +10,32 @@
 class_name RollTab
 extends Control
 
+@onready var RT_dice_area_SH: Control = $DiceArea
+var RT_rng_IN: RandomNumberGenerator
+
 
 func _ready() -> void:
+    RT_rng_IN = RandomNumberGenerator.new()
+    RT_rng_IN.randomize()
     get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
 
 
 func _on_roll_executed(result: Dictionary) -> void:
     print("Result:", result)
+    play_basic_animation()
+
+
+func play_basic_animation() -> void:
+    var area_size: Vector2 = RT_dice_area_SH.size
+    for i in range(3):
+        var lbl := Label.new()
+        lbl.text = str(RT_rng_IN.randi_range(1, 6))
+        lbl.modulate.a = 0.0
+        RT_dice_area_SH.add_child(lbl)
+        var pos_x := RT_rng_IN.randi_range(0, int(area_size.x) - lbl.size.x)
+        var pos_y := RT_rng_IN.randi_range(0, int(area_size.y) - lbl.size.y)
+        lbl.position = Vector2(pos_x, pos_y)
+        var tw := create_tween()
+        tw.tween_property(lbl, "modulate:a", 1.0, 0.15)
+        tw.tween_property(lbl, "modulate:a", 0.0, 0.15).set_delay(0.15)
+        tw.finished.connect(lbl.queue_free)


### PR DESCRIPTION
## Summary
- animate dice labels in RollTab after a roll
- randomize dice positions using RNG
- ensure DiceArea covers the tab for animations

## Testing
- `bash LIVEdie/fix_indent.sh $(git diff --name-only --cached -- '*.gd') >/dev/null`
- `gdlint LIVEdie/GOGOT/scripts/RollTab.gd`
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet restore BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-cache --nologo`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68719dd4dc6483299fd0f35d8119ae1f