### PR TITLE
Add UI scaling manager and resize controls

### DIFF
--- a/LIVEdie/GOGOT/project.godot
+++ b/LIVEdie/GOGOT/project.godot
@@ -21,6 +21,7 @@ config/features=PackedStringArray("4.4")
 UIEventBus="res://scripts/UIEventBus.gd"
 RNGManager="res://scripts/RNGManager.gd"
 RollExecutor="res://scripts/RollExecutor.gd"
+UIStyleManager="res://scripts/UIStyleManager.gd"
 
 [display]
 

--- a/LIVEdie/GOGOT/scenes/HistoryTab.tscn
+++ b/LIVEdie/GOGOT/scenes/HistoryTab.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=2 format=3 uid="uid://historytab"]
 
 [ext_resource type="Script" path="res://scripts/HistoryTab.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
 ; HistoryTab – scrollable list of past rolls
 ; Future: populate with roll summaries from log
 [node name="HistoryTab" type="ScrollContainer"]
@@ -10,4 +11,7 @@ script = ExtResource("1")
 ; Each child will be a HistoryItem label
 
 [node name="HistoryPlaceholder" type="Label" parent="HistoryVBox"]
+script = ExtResource("2")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "(History list placeholder)"

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -1,4 +1,5 @@
-[gd_scene format=3 uid="uid://keyboardtab"]
+[gd_scene load_steps=1 format=3 uid="uid://keyboardtab"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="1"]
 
 [node name="KeyboardTab" type="Control"]
 physics_interpolation_mode = 0
@@ -10,6 +11,9 @@ layout_mode = 0
 
 [node name="LabelA" type="Label" parent="PageA"]
 layout_mode = 2
+script = ExtResource("1")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "Numeric Page (A)"
 
 [node name="PageB" type="GridContainer" parent="."]
@@ -17,4 +21,7 @@ layout_mode = 0
 
 [node name="LabelB" type="Label" parent="PageB"]
 layout_mode = 2
+script = ExtResource("1")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "Notation Page (B)"

--- a/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
+++ b/LIVEdie/GOGOT/scenes/KeyboardTab.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=1 format=3 uid="uid://keyboardtab"]
-[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="1"]
+[gd_scene load_steps=2 format=3 uid="uid://keyboardtab"]
+
+[ext_resource type="Script" uid="uid://bo5xejq322083" path="res://scripts/UIScalable.gd" id="1"]
 
 [node name="KeyboardTab" type="Control"]
 physics_interpolation_mode = 0
@@ -11,17 +12,15 @@ layout_mode = 0
 
 [node name="LabelA" type="Label" parent="PageA"]
 layout_mode = 2
-script = ExtResource("1")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(0, 0)
 text = "Numeric Page (A)"
+script = ExtResource("1")
+SC_base_size_IN = Vector2(0, 0)
 
 [node name="PageB" type="GridContainer" parent="."]
 layout_mode = 0
 
 [node name="LabelB" type="Label" parent="PageB"]
 layout_mode = 2
-script = ExtResource("1")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(0, 0)
 text = "Notation Page (B)"
+script = ExtResource("1")
+SC_base_size_IN = Vector2(0, 0)

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://mainui"]
+[gd_scene load_steps=9 format=3 uid="uid://mainui"]
 
 [ext_resource type="PackedScene" uid="uid://rolltab" path="res://scenes/RollTab.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://historytab" path="res://scenes/HistoryTab.tscn" id="2"]
@@ -7,7 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://keyboardtab" path="res://scenes/KeyboardTab.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://qrtab" path="res://scenes/QRTab.tscn" id="6"]
 [ext_resource type="Script" uid="uid://bqmovjblayg38" path="res://scripts/DicePad.gd" id="7"]
-[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="8"]
+[ext_resource type="Script" uid="uid://bo5xejq322083" path="res://scripts/UIScalable.gd" id="8"]
 
 [node name="MainUI" type="Control"]
 custom_minimum_size = Vector2(1080, 1920)
@@ -28,10 +28,10 @@ layout_mode = 2
 
 [node name="TitleLabel" type="Label" parent="TopBar/BarHBox"]
 layout_mode = 2
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(0, 0)
 text = "LIVEdie"
+script = ExtResource("8")
+SC_base_size_IN = Vector2(0, 0)
+SC_base_font_IN = 32
 
 [node name="Spacer" type="Control" parent="TopBar/BarHBox"]
 layout_mode = 2
@@ -62,51 +62,45 @@ size_flags_horizontal = 2
 
 [node name="Qty1" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "1×"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="Qty2" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "2×"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="Qty3" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "3×"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="Qty4" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "4×"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="Qty5" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "5×"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="Qty10" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "10×"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="QtyRightSpacer" type="Control" parent="DicePad/QtyRow"]
 layout_mode = 2
@@ -121,51 +115,45 @@ size_flags_horizontal = 2
 
 [node name="D4" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D4"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="D6" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D6"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="D8" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D8"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="D10" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D10"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="D12" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D12"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="D20" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D20"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="DiceRightSpacer" type="Control" parent="DicePad/CommonDiceRow"]
 layout_mode = 2
@@ -180,51 +168,46 @@ size_flags_horizontal = 2
 
 [node name="D2Btn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D2"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="D100Btn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D100"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="PipeBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "|"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="DXPromptBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "DX?"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="RollBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(120, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(120, 80)
 layout_mode = 2
 text = "ROLL"
+script = ExtResource("8")
+SC_base_size_IN = Vector2(120, 80)
+SC_base_font_IN = 32
 
 [node name="BackspaceBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
-script = ExtResource("8")
-SC_base_font_IN = 32
-SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "⌫"
+script = ExtResource("8")
+SC_base_font_IN = 32
 
 [node name="AdvancedRightSpacer" type="Control" parent="DicePad/AdvancedRow"]
 layout_mode = 2
@@ -232,21 +215,19 @@ size_flags_horizontal = 2
 
 [node name="SystemDropdown" type="Button" parent="DicePad"]
 custom_minimum_size = Vector2(48, 48)
-script = ExtResource("8")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(48, 48)
 layout_mode = 2
 size_flags_horizontal = 4
 text = "▼"
+script = ExtResource("8")
+SC_base_size_IN = Vector2(48, 48)
 
 [node name="QueueLabel" type="Label" parent="DicePad"]
 custom_minimum_size = Vector2(0, 40)
-script = ExtResource("8")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(0, 40)
 layout_mode = 2
 text = "(no dice)"
 autowrap_mode = 1
+script = ExtResource("8")
+SC_base_size_IN = Vector2(0, 40)
 
 [node name="LowerPane" type="PanelContainer" parent="."]
 layout_mode = 0

--- a/LIVEdie/GOGOT/scenes/MainUI.tscn
+++ b/LIVEdie/GOGOT/scenes/MainUI.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://keyboardtab" path="res://scenes/KeyboardTab.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://qrtab" path="res://scenes/QRTab.tscn" id="6"]
 [ext_resource type="Script" uid="uid://bqmovjblayg38" path="res://scripts/DicePad.gd" id="7"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="8"]
 
 [node name="MainUI" type="Control"]
 custom_minimum_size = Vector2(1080, 1920)
@@ -27,6 +28,9 @@ layout_mode = 2
 
 [node name="TitleLabel" type="Label" parent="TopBar/BarHBox"]
 layout_mode = 2
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(0, 0)
 text = "LIVEdie"
 
 [node name="Spacer" type="Control" parent="TopBar/BarHBox"]
@@ -58,31 +62,49 @@ size_flags_horizontal = 2
 
 [node name="Qty1" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "1×"
 
 [node name="Qty2" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "2×"
 
 [node name="Qty3" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "3×"
 
 [node name="Qty4" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "4×"
 
 [node name="Qty5" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "5×"
 
 [node name="Qty10" type="Button" parent="DicePad/QtyRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "10×"
 
@@ -99,31 +121,49 @@ size_flags_horizontal = 2
 
 [node name="D4" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D4"
 
 [node name="D6" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D6"
 
 [node name="D8" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D8"
 
 [node name="D10" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D10"
 
 [node name="D12" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D12"
 
 [node name="D20" type="Button" parent="DicePad/CommonDiceRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D20"
 
@@ -140,31 +180,49 @@ size_flags_horizontal = 2
 
 [node name="D2Btn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D2"
 
 [node name="D100Btn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "D100"
 
 [node name="PipeBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "|"
 
 [node name="DXPromptBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "DX?"
 
 [node name="RollBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(120, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(120, 80)
 layout_mode = 2
 text = "ROLL"
 
 [node name="BackspaceBtn" type="Button" parent="DicePad/AdvancedRow"]
 custom_minimum_size = Vector2(80, 80)
+script = ExtResource("8")
+SC_base_font_IN = 32
+SC_base_size_IN = Vector2(80, 80)
 layout_mode = 2
 text = "⌫"
 
@@ -174,12 +232,18 @@ size_flags_horizontal = 2
 
 [node name="SystemDropdown" type="Button" parent="DicePad"]
 custom_minimum_size = Vector2(48, 48)
+script = ExtResource("8")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(48, 48)
 layout_mode = 2
 size_flags_horizontal = 4
 text = "▼"
 
 [node name="QueueLabel" type="Label" parent="DicePad"]
 custom_minimum_size = Vector2(0, 40)
+script = ExtResource("8")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 40)
 layout_mode = 2
 text = "(no dice)"
 autowrap_mode = 1

--- a/LIVEdie/GOGOT/scenes/QRTab.tscn
+++ b/LIVEdie/GOGOT/scenes/QRTab.tscn
@@ -1,4 +1,5 @@
-[gd_scene load_steps=1 format=3 uid="uid://qrtab"]
+[gd_scene load_steps=2 format=3 uid="uid://qrtab"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="1"]
 ; QRTab – placeholder for QR code connection
 ; Next step: generate code from session info
 [node name="QRTab" type="Control"]
@@ -7,4 +8,7 @@
 anchor_right = 1.0
 anchor_bottom = 1.0
 [node name="PlaceholderLabel" type="Label" parent="."]
+script = ExtResource("1")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "(QR code placeholder)"

--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://rolltab"]
 
 [ext_resource type="Script" uid="uid://gctxcv00gj5w" path="res://scripts/RollTab.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
+[ext_resource type="Script" uid="uid://bo5xejq322083" path="res://scripts/UIScalable.gd" id="2"]
 
 [node name="RollTab" type="Control"]
 layout_mode = 3
@@ -15,7 +15,6 @@ anchor_bottom = 1.0
 
 [node name="PlaceholderLabel" type="Label" parent="."]
 layout_mode = 0
-script = ExtResource("2")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(0, 0)
 text = "Roll View (animation)"
+script = ExtResource("2")
+SC_base_size_IN = Vector2(0, 0)

--- a/LIVEdie/GOGOT/scenes/RollTab.tscn
+++ b/LIVEdie/GOGOT/scenes/RollTab.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://rolltab"]
+[gd_scene load_steps=3 format=3 uid="uid://rolltab"]
 
 [ext_resource type="Script" uid="uid://gctxcv00gj5w" path="res://scripts/RollTab.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
 
 [node name="RollTab" type="Control"]
 layout_mode = 3
@@ -14,4 +15,7 @@ anchor_bottom = 1.0
 
 [node name="PlaceholderLabel" type="Label" parent="."]
 layout_mode = 0
+script = ExtResource("2")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "Roll View (animation)"

--- a/LIVEdie/GOGOT/scenes/SettingsTab.tscn
+++ b/LIVEdie/GOGOT/scenes/SettingsTab.tscn
@@ -1,12 +1,27 @@
-[gd_scene load_steps=1 format=3 uid="uid://settingstab"]
+[gd_scene load_steps=2 format=3 uid="uid://settingstab"]
+
+[ext_resource type="Script" path="res://scripts/SettingsTab.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
 ; SettingsTab – UI preferences
 ; Next: hook controls to config storage
 [node name="SettingsTab" type="VBoxContainer"]
+script = ExtResource("1")
 
 [node name="ThemeColor" type="ColorPickerButton" parent="."]
 [node name="PlaceholderLabel" type="Label" parent="."]
+script = ExtResource("2")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "(Settings placeholder)"
-[node name="FontScaleSlider" type="HSlider" parent="."]
+[node name="UIScaleSlider" type="HSlider" parent="."]
+min_value = 0.5
+max_value = 2.0
+step = 0.1
+value = 1.0
+tooltip_text = "UI Scale"
+script = ExtResource("2")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(200, 40)
 [node name="AnimLevelOption" type="OptionButton" parent="."]
 [node name="SettingsSpacer" type="Control" parent="."]
 size_flags_vertical = 3

--- a/LIVEdie/GOGOT/scenes/SystemsTab.tscn
+++ b/LIVEdie/GOGOT/scenes/SystemsTab.tscn
@@ -1,4 +1,5 @@
-[gd_scene load_steps=1 format=3 uid="uid://systemstab"]
+[gd_scene load_steps=2 format=3 uid="uid://systemstab"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="1"]
 ; SystemsTab – choose rulesets, star favorites
 ; TODO: connect selection to UIEventBus system_selected
 [node name="SystemsTab" type="ScrollContainer"]
@@ -7,4 +8,7 @@
 ; Placeholder buttons with star checkboxes
 
 [node name="SystemsPlaceholder" type="Label" parent="SystemVBox"]
+script = ExtResource("1")
+SC_base_font_IN = 24
+SC_base_size_IN = Vector2(0, 0)
 text = "(Systems list placeholder)"

--- a/LIVEdie/GOGOT/scripts/SettingsTab.gd
+++ b/LIVEdie/GOGOT/scripts/SettingsTab.gd
@@ -1,0 +1,22 @@
+###############################################################
+# LIVEdie/GOGOT/scripts/SettingsTab.gd
+# Key Classes      • SettingsTab – handles settings interactions
+# Key Functions    • _on_scale_changed
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • UIStyleManager.gd
+# Last Major Rev   • 24-07-13 – connect UI scale slider
+###############################################################
+class_name SettingsTab
+extends VBoxContainer
+
+@onready var ST_scale_slider_SH: HSlider = $UIScaleSlider
+
+
+func _ready() -> void:
+    ST_scale_slider_SH.value_changed.connect(_on_scale_changed)
+    ST_scale_slider_SH.value = get_node("/root/UIStyleManager").US_scale_SH
+
+
+func _on_scale_changed(value: float) -> void:
+    get_node("/root/UIStyleManager").set_scale(value)

--- a/LIVEdie/GOGOT/scripts/UIScalable.gd
+++ b/LIVEdie/GOGOT/scripts/UIScalable.gd
@@ -1,0 +1,26 @@
+###############################################################
+# LIVEdie/GOGOT/scripts/UIScalable.gd
+# Key Classes      • UIScalable – helper for resizable UI controls
+# Key Functions    • update_ui_scale
+# Critical Consts  • (none)
+# Editor Exports   • SC_base_size_IN: Vector2 – Range base size
+#                  • SC_base_font_IN: int – Base font size
+# Dependencies     • UIStyleManager.gd
+# Last Major Rev   • 24-07-13 – initial version
+###############################################################
+class_name UIScalable
+extends Control
+
+@export var SC_base_size_IN: Vector2 = Vector2(80, 80)
+@export var SC_base_font_IN: int = 24
+
+
+func _ready() -> void:
+    var mgr := get_node("/root/UIStyleManager") as UIStyleManager
+    mgr.scale_changed.connect(update_ui_scale)
+    update_ui_scale(mgr.US_scale_SH)
+
+
+func update_ui_scale(scale: float) -> void:
+    custom_minimum_size = SC_base_size_IN * scale
+    add_theme_font_size_override("font_size", int(SC_base_font_IN * scale))

--- a/LIVEdie/GOGOT/scripts/UIStyleManager.gd
+++ b/LIVEdie/GOGOT/scripts/UIStyleManager.gd
@@ -1,0 +1,22 @@
+###############################################################
+# LIVEdie/GOGOT/scripts/UIStyleManager.gd
+# Key Classes      • UIStyleManager – global UI scaling manager
+# Key Functions    • set_scale
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • (none)
+# Last Major Rev   • 24-07-13 – add dynamic UI scaling
+###############################################################
+class_name UIStyleManager
+extends Node
+signal scale_changed(new_scale: float)
+
+var US_scale_SH: float = 1.0:
+    set = set_scale
+
+
+func set_scale(v: float) -> void:
+    v = clamp(v, 0.5, 2.0)
+    if !is_equal_approx(v, US_scale_SH):
+        US_scale_SH = v
+        emit_signal("scale_changed", US_scale_SH)


### PR DESCRIPTION
## Summary
- add `UIStyleManager` autoload for runtime scaling
- implement `UIScalable` helper for buttons and labels
- create `SettingsTab.gd` and hook scale slider to manager
- register UI scale slider in `SettingsTab.tscn`
- attach scaling script to main buttons and labels
- register autoload in `project.godot`

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln`

------
https://chatgpt.com/codex/tasks/task_e_6872990861fc8329b9a7631083b165ca