### PR TITLE
Implement dynamic roll history log

### DIFF
--- a/LIVEdie/GOGOT/helpers/TimeUtils.gd
+++ b/LIVEdie/GOGOT/helpers/TimeUtils.gd
@@ -1,0 +1,31 @@
+###############################################################
+# LIVEdie/GOGOT/helpers/TimeUtils.gd
+# Key Classes      • TimeUtils – helper for friendly timestamps
+# Key Functions    • friendly
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • (none)
+# Last Major Rev   • 24-07-14 – initial version
+###############################################################
+class_name TimeUtils
+extends Node
+
+
+static func friendly(epoch_ms: int) -> String:
+    var now = int(Time.get_unix_time_from_system() * 1000)
+    var d = now - epoch_ms
+    if d < 60_000:
+        return Time.get_datetime_string_from_unix_time(epoch_ms / 1000.0, true)
+    if d < 3_600_000:
+        return Time.get_datetime_string_from_unix_time(epoch_ms / 1000.0).substr(0, 8)
+    if d < 86_400_000:
+        return Time.get_datetime_string_from_unix_time(epoch_ms / 1000.0).substr(0, 5)
+    if d < 172_800_000:
+        return (
+            "Yesterday " + Time.get_datetime_string_from_unix_time(epoch_ms / 1000.0).substr(0, 5)
+        )
+    return (
+        Time.get_date_string_from_unix_time(epoch_ms / 1000.0)
+        + " "
+        + Time.get_datetime_string_from_unix_time(epoch_ms / 1000.0).substr(0, 5)
+    )

--- a/LIVEdie/GOGOT/scenes/HistoryTab.tscn
+++ b/LIVEdie/GOGOT/scenes/HistoryTab.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://historytab"]
 
 [ext_resource type="Script" path="res://scripts/HistoryTab.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
 ; HistoryTab – scrollable list of past rolls
 ; Future: populate with roll summaries from log
 [node name="HistoryTab" type="ScrollContainer"]
@@ -10,8 +9,3 @@
 script = ExtResource("1")
 ; Each child will be a HistoryItem label
 
-[node name="HistoryPlaceholder" type="Label" parent="HistoryVBox"]
-script = ExtResource("2")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(0, 0)
-text = "(History list placeholder)"

--- a/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.gd
+++ b/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.gd
@@ -1,0 +1,27 @@
+###############################################################
+# LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.gd
+# Key Classes      • RollHistoryEntry – row in history list
+# Key Functions    • _on_Header_gui_input
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • UIScalable.gd
+# Last Major Rev   • 24-07-14 – initial version
+###############################################################
+class_name RollHistoryEntry
+extends VBoxContainer
+
+signal toggled(debug_visible: bool)
+
+@onready var RH_expanded_SH: VBoxContainer = $BG/Main/Expanded
+@onready var RH_json_label_SH: Label = $BG/Main/Expanded/JSONLabel
+@onready var RH_arrow_SH: TextureRect = $BG/Main/Header/ArrowIcon
+var RH_stage_SH := 0
+
+
+func _on_Header_gui_input(ev: InputEvent) -> void:
+    if ev is InputEventMouseButton and ev.pressed:
+        RH_stage_SH = (RH_stage_SH + 1) % 3
+        RH_expanded_SH.visible = RH_stage_SH > 0
+        RH_json_label_SH.visible = RH_stage_SH == 2
+        RH_arrow_SH.rotation_degrees = 0 if RH_stage_SH == 0 else 90
+        emit_signal("toggled", RH_json_label_SH.visible)

--- a/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.tscn
+++ b/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scenes/ui/RollHistoryEntry.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
+
+[node name="RollHistoryEntry" type="VBoxContainer"]
+script = ExtResource("1")
+
+[node name="BG" type="ColorRect" parent="."]
+color = Color(0, 0, 0, 1)
+
+[node name="Main" type="VBoxContainer" parent="BG"]
+
+[node name="Header" type="HBoxContainer" parent="BG/Main"]
+
+[connection signal="gui_input" from="Header" to="." method="_on_Header_gui_input"]
+
+[node name="TimestampLabel" type="Label" parent="BG/Main/Header"]
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0,40)
+
+[node name="SummaryLabel" type="Label" parent="BG/Main/Header"]
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0,40)
+
+[node name="ArrowIcon" type="TextureRect" parent="BG/Main/Header"]
+expand_mode = 0
+stretch_mode = 1
+texture_filter = 1
+
+[node name="Expanded" type="VBoxContainer" parent="BG/Main"]
+visible = false
+
+[node name="MetaLabel" type="Label" parent="BG/Main/Expanded"]
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0,40)
+
+[node name="JSONLabel" type="Label" parent="BG/Main/Expanded"]
+visible = false
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0,40)

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -5,55 +5,45 @@
 # Critical Consts  • (none)
 # Editor Exports   • (none)
 # Dependencies     • RollExecutor.gd
-# Last Major Rev   • 24-07-14 – populate dummy history
+# Last Major Rev   • 24-07-14 – add dynamic history entries
 ###############################################################
 class_name HistoryTab
 extends VBoxContainer
 signal history_updated
 
-const HT_SCALE_SCRIPT_IN := preload("res://scripts/UIScalable.gd")
+const HT_ENTRY_SCENE_IN := preload("res://scenes/ui/RollHistoryEntry.tscn")
+const HT_TIME_UTIL_IN := preload("res://helpers/TimeUtils.gd")
 
 
 func _ready() -> void:
     get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
-    _HT_populate_dummy_IN()
-
-
-func _HT_populate_dummy_IN() -> void:
     if has_node("HistoryPlaceholder"):
         get_node("HistoryPlaceholder").queue_free()
-    for i in range(100, 0, -1):
-        var label := Label.new()
-        label.set_script(HT_SCALE_SCRIPT_IN)
-        label.SC_base_font_IN = 24
-        label.SC_base_size_IN = Vector2(0, 0)
-        label.text = "Roll %d (placeholder)" % i
-        add_child(label)
-
-
-func _HT_build_snippet_IN(sec: Dictionary) -> String:
-    var snippet := ""
-    if sec.rolls.size() > 1:
-        snippet = " + ".join(sec.rolls.map(func(r): return str(r)))
-    else:
-        snippet = str(sec.value)
-    if sec.has("meta"):
-        var extras: Array = []
-        if sec.meta.succ > 0:
-            extras.append("%d successes" % sec.meta.succ)
-        if sec.meta.crit > 0:
-            extras.append("%d crit" % sec.meta.crit)
-        if extras.size() > 0:
-            snippet += " (" + ", ".join(extras) + ")"
-    return snippet
 
 
 func _on_roll_executed(result: Dictionary) -> void:
-    var entry := Label.new()
-    var parts: Array = []
-    for sec in result.sections:
-        parts.append(_HT_build_snippet_IN(sec))
-    var text := "%s → %s" % [result.notation, " | ".join(parts)]
-    entry.text = text
-    add_child(entry)
+    var entry: RollHistoryEntry = HT_ENTRY_SCENE_IN.instantiate()
+    var ts: int = result.get("timestamp", int(Time.get_unix_time_from_system() * 1000))
+    entry.get_node("BG/Main/Header/TimestampLabel").text = HT_TIME_UTIL_IN.friendly(ts)
+    entry.get_node("BG/Main/Header/TimestampLabel").tooltip_text = (
+        Time.get_datetime_string_from_unix_time(ts / 1000.0, true)
+    )
+    var rolls: Array = []
+    for r in result.get("rolls", []):
+        rolls.append(str(r))
+    entry.get_node("BG/Main/Header/SummaryLabel").text = (
+        "%s → %s = %d"
+        % [result.get("notation", ""), " + ".join(rolls), int(result.get("total", 0))]
+    )
+    var meta: Dictionary = result.get("meta", {"succ": 0, "crit": 0, "fail": 0})
+    entry.get_node("BG/Main/Expanded/MetaLabel").text = (
+        "Succ: %d | Crit: %d | Fail: %d"
+        % [int(meta.get("succ", 0)), int(meta.get("crit", 0)), int(meta.get("fail", 0))]
+    )
+    entry.get_node("BG/Main/Expanded/JSONLabel").text = JSON.stringify(result, "\t")
+    var idx := get_child_count()
+    entry.get_node("BG").color = Color("#1c1c1c") if idx % 2 == 0 else Color("#222222")
+    add_child(entry, true, 0)
+    await get_tree().process_frame
+    (get_parent() as ScrollContainer).scroll_vertical = 0
     history_updated.emit()

--- a/LIVEdie/GOGOT/tests/test_history_join.gd
+++ b/LIVEdie/GOGOT/tests/test_history_join.gd
@@ -4,9 +4,11 @@ extends SceneTree
 func _init() -> void:
     var ht: HistoryTab = preload("res://scripts/HistoryTab.gd").new()
     root.add_child(ht)
-    var dummy := {"notation": "3d6", "sections": [{"rolls": [4, 2, 6], "value": 12}]}
+    var dummy := {"notation": "3d6", "rolls": [4, 2, 6], "total": 12}
     ht._on_roll_executed(dummy)
     assert(ht.get_child_count() == 1)
-    assert(ht.get_child(0).text.ends_with("4 + 2 + 6"))
+    var entry = ht.get_child(0)
+    var text = entry.get_node("BG/Main/Header/SummaryLabel").text
+    assert(text == "3d6 \u2192 4 + 2 + 6 = 12")
     print("History join test passed")
     quit()

--- a/LIVEdie/GOGOT/tests/test_history_multi_section.gd
+++ b/LIVEdie/GOGOT/tests/test_history_multi_section.gd
@@ -6,18 +6,14 @@ func _init() -> void:
     root.add_child(ht)
     var dummy = {
         "notation": "2d6>=5 | 1d20cs>=20",
-        "sections":
-        [
-            {"rolls": [5, 6], "value": 2, "meta": {"succ": 2, "crit": 0, "fail": 0}},
-            {"rolls": [20], "value": 1, "meta": {"succ": 1, "crit": 1, "fail": 0}}
-        ]
+        "rolls": [5, 6, 20],
+        "total": 3,
+        "meta": {"succ": 3, "crit": 1, "fail": 0}
     }
     ht._on_roll_executed(dummy)
     assert(ht.get_child_count() == 1)
-    var text = ht.get_child(0).text
-    var parts = text.split(" → ")[1].split(" | ")
-    assert(parts.size() == 2)
-    assert(parts[0].find("success") != -1)
-    assert(parts[1].find("crit") != -1)
+    var entry = ht.get_child(0)
+    var meta_text = entry.get_node("BG/Main/Expanded/MetaLabel").text
+    assert(meta_text == "Succ: 3 | Crit: 1 | Fail: 0")
     print("History multi-section test passed")
     quit()

--- a/LIVEdie/GOGOT/tests/test_history_no_dup_parts.gd
+++ b/LIVEdie/GOGOT/tests/test_history_no_dup_parts.gd
@@ -4,12 +4,9 @@ extends SceneTree
 func _init() -> void:
     var ht: HistoryTab = preload("res://scripts/HistoryTab.gd").new()
     root.add_child(ht)
-    var dummy = {
-        "notation": "1d4 | 1d6",
-        "sections": [{"rolls": [3], "value": 3}, {"rolls": [5], "value": 5}]
-    }
+    var dummy = {"notation": "1d4 | 1d6", "rolls": [3, 5], "total": 8}
     ht._on_roll_executed(dummy)
-    var parts = ht.get_child(0).text.split(" → ")[1].split(" | ")
-    assert(parts.size() == 2)
+    var text = ht.get_child(0).get_node("BG/Main/Header/SummaryLabel").text
+    assert(text == "1d4 | 1d6 \u2192 3 + 5 = 8")
     print("History no dup parts test passed")
     quit()


### PR DESCRIPTION
## Summary
- clean up HistoryTab scene
- add RollHistoryEntry UI scene with interactive expansion
- create TimeUtils helper for friendly timestamps
- refactor HistoryTab logic to build entries from executed rolls
- update history tests for new behaviour

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --no-restore --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6872ae8396a883299ce1575248a342d9