### PR TITLE
Implement rich roll history

### DIFF
--- a/LIVEdie/GOGOT/helpers/TimeUtils.gd
+++ b/LIVEdie/GOGOT/helpers/TimeUtils.gd
@@ -1,0 +1,30 @@
+###############################################################
+# LIVEdie/GOGOT/helpers/TimeUtils.gd
+# Key Classes      • TimeUtils – helper for friendly timestamps
+# Key Functions    • friendly
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • (none)
+# Last Major Rev   • 24-07-14 – initial version
+###############################################################
+class_name TimeUtils
+extends Node
+
+
+static func friendly(epoch_ms: int) -> String:
+    var now := Time.get_unix_time_from_system() * 1000
+    var d := now - epoch_ms
+    var sec := epoch_ms / 1000
+    if d < 60_000:
+        return Time.get_datetime_string_from_unix_time(sec, true)
+    if d < 3_600_000:
+        return Time.get_datetime_string_from_unix_time(sec).substr(0, 8)
+    if d < 86_400_000:
+        return Time.get_datetime_string_from_unix_time(sec).substr(0, 5)
+    if d < 172_800_000:
+        return "Yesterday " + Time.get_datetime_string_from_unix_time(sec).substr(0, 5)
+    return (
+        Time.get_date_string_from_unix_time(sec)
+        + " "
+        + Time.get_datetime_string_from_unix_time(sec).substr(0, 5)
+    )

--- a/LIVEdie/GOGOT/scenes/HistoryTab.tscn
+++ b/LIVEdie/GOGOT/scenes/HistoryTab.tscn
@@ -1,17 +1,8 @@
 [gd_scene load_steps=2 format=3 uid="uid://historytab"]
 
 [ext_resource type="Script" path="res://scripts/HistoryTab.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
-; HistoryTab – scrollable list of past rolls
-; Future: populate with roll summaries from log
+
 [node name="HistoryTab" type="ScrollContainer"]
 
 [node name="HistoryVBox" type="VBoxContainer" parent="."]
 script = ExtResource("1")
-; Each child will be a HistoryItem label
-
-[node name="HistoryPlaceholder" type="Label" parent="HistoryVBox"]
-script = ExtResource("2")
-SC_base_font_IN = 24
-SC_base_size_IN = Vector2(0, 0)
-text = "(History list placeholder)"

--- a/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.gd
+++ b/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.gd
@@ -1,0 +1,27 @@
+###############################################################
+# LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.gd
+# Key Classes      • RollHistoryEntry – UI row for roll log
+# Key Functions    • _on_Header_gui_input
+# Critical Consts  • (none)
+# Editor Exports   • (none)
+# Dependencies     • UIScalable.gd
+# Last Major Rev   • 24-07-14 – initial version
+###############################################################
+class_name RollHistoryEntry
+extends VBoxContainer
+
+signal toggled(debug_visible: bool)
+
+@onready var RH_expanded_SH: VBoxContainer = $BG/Main/Expanded
+@onready var RH_json_label_SH: Label = $BG/Main/Expanded/JSONLabel
+@onready var RH_arrow_SH: TextureRect = $BG/Main/Header/ArrowIcon
+var RH_stage_IN := 0
+
+
+func _on_Header_gui_input(ev: InputEvent) -> void:
+    if ev is InputEventMouseButton and ev.pressed:
+        RH_stage_IN = (RH_stage_IN + 1) % 3
+        RH_expanded_SH.visible = RH_stage_IN > 0
+        RH_json_label_SH.visible = RH_stage_IN == 2
+        RH_arrow_SH.rotation_degrees = 0 if RH_stage_IN == 0 else 90
+        toggled.emit(RH_json_label_SH.visible)

--- a/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.tscn
+++ b/LIVEdie/GOGOT/scenes/ui/RollHistoryEntry.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=2 format=3 uid="uid://rollhistoryentry"]
+
+[ext_resource type="Script" path="res://scenes/ui/RollHistoryEntry.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/UIScalable.gd" id="2"]
+
+[node name="RollHistoryEntry" type="VBoxContainer"]
+script = ExtResource("1")
+
+[node name="BG" type="ColorRect" parent="."]
+
+[node name="Main" type="VBoxContainer" parent="BG"]
+
+[node name="Header" type="HBoxContainer" parent="BG/Main"]
+
+[node name="TimestampLabel" type="Label" parent="BG/Main/Header"]
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0, 40)
+
+[node name="SummaryLabel" type="Label" parent="BG/Main/Header"]
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0, 40)
+
+[node name="ArrowIcon" type="TextureRect" parent="BG/Main/Header"]
+custom_minimum_size = Vector2(40, 40)
+
+[node name="Expanded" type="VBoxContainer" parent="BG/Main"]
+visible = false
+
+[node name="MetaLabel" type="Label" parent="BG/Main/Expanded"]
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0, 40)
+
+[node name="JSONLabel" type="Label" parent="BG/Main/Expanded"]
+visible = false
+script = ExtResource("2")
+SC_base_font_IN = 20
+SC_base_size_IN = Vector2(0, 40)

--- a/LIVEdie/GOGOT/scripts/HistoryTab.gd
+++ b/LIVEdie/GOGOT/scripts/HistoryTab.gd
@@ -4,56 +4,43 @@
 # Key Functions    • _on_roll_executed
 # Critical Consts  • (none)
 # Editor Exports   • (none)
-# Dependencies     • RollExecutor.gd
-# Last Major Rev   • 24-07-14 – populate dummy history
+# Dependencies     • RollExecutor.gd, TimeUtils.gd
+# Last Major Rev   • 24-07-14 – roll history UI
 ###############################################################
 class_name HistoryTab
 extends VBoxContainer
 signal history_updated
 
-const HT_SCALE_SCRIPT_IN := preload("res://scripts/UIScalable.gd")
+const HT_ENTRY_SCENE_IN := preload("res://scenes/ui/RollHistoryEntry.tscn")
+const HT_TIME_UTILS_IN := preload("res://helpers/TimeUtils.gd")
 
 
 func _ready() -> void:
     get_node("/root/RollExecutor").roll_executed.connect(_on_roll_executed)
-    _HT_populate_dummy_IN()
-
-
-func _HT_populate_dummy_IN() -> void:
-    if has_node("HistoryPlaceholder"):
-        get_node("HistoryPlaceholder").queue_free()
-    for i in range(100, 0, -1):
-        var label := Label.new()
-        label.set_script(HT_SCALE_SCRIPT_IN)
-        label.SC_base_font_IN = 24
-        label.SC_base_size_IN = Vector2(0, 0)
-        label.text = "Roll %d (placeholder)" % i
-        add_child(label)
-
-
-func _HT_build_snippet_IN(sec: Dictionary) -> String:
-    var snippet := ""
-    if sec.rolls.size() > 1:
-        snippet = " + ".join(sec.rolls.map(func(r): return str(r)))
-    else:
-        snippet = str(sec.value)
-    if sec.has("meta"):
-        var extras: Array = []
-        if sec.meta.succ > 0:
-            extras.append("%d successes" % sec.meta.succ)
-        if sec.meta.crit > 0:
-            extras.append("%d crit" % sec.meta.crit)
-        if extras.size() > 0:
-            snippet += " (" + ", ".join(extras) + ")"
-    return snippet
 
 
 func _on_roll_executed(result: Dictionary) -> void:
-    var entry := Label.new()
-    var parts: Array = []
-    for sec in result.sections:
-        parts.append(_HT_build_snippet_IN(sec))
-    var text := "%s → %s" % [result.notation, " | ".join(parts)]
-    entry.text = text
+    var entry: RollHistoryEntry = HT_ENTRY_SCENE_IN.instantiate()
+    var ts_lbl: Label = entry.get_node("BG/Main/Header/TimestampLabel")
+    ts_lbl.text = HT_TIME_UTILS_IN.friendly(result.timestamp)
+    var sec = result.timestamp / 1000
+    ts_lbl.hint_tooltip = Time.get_datetime_string_from_unix_time(sec, true)
+    var sum_lbl: Label = entry.get_node("BG/Main/Header/SummaryLabel")
+    sum_lbl.text = (
+        "%s → %s = %d"
+        % [result.notation, " + ".join(result.rolls.map(func(r): return str(r))), result.total]
+    )
+    var meta_lbl: Label = entry.get_node("BG/Main/Expanded/MetaLabel")
+    meta_lbl.text = (
+        "Succ: %d | Crit: %d | Fail: %d" % [result.meta.succ, result.meta.crit, result.meta.fail]
+    )
+    var json_lbl: Label = entry.get_node("BG/Main/Expanded/JSONLabel")
+    json_lbl.text = JSON.stringify(result, "\t")
+    var bg: ColorRect = entry.get_node("BG")
+    bg.color = Color("#1c1c1c") if get_child_count() % 2 == 0 else Color("#222222")
     add_child(entry)
+    move_child(entry, 0)
+    await get_tree().process_frame
+    if get_parent() is ScrollContainer:
+        (get_parent() as ScrollContainer).scroll_vertical = 0
     history_updated.emit()


### PR DESCRIPTION
## Summary
- add reusable `RollHistoryEntry` scene
- show smart timestamps via new `TimeUtils`
- rewrite `HistoryTab` to insert entries dynamically
- clean the HistoryTab scene to remove placeholder

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build --nologo` *(fails: no project)*

------
https://chatgpt.com/codex/tasks/task_e_6872ae8396a883299ce1575248a342d9