### PR TITLE
Fix history entry sizing for UI scaling

### DIFF
--- a/LIVEdie/GOGOT/scripts/UIScalable.gd
+++ b/LIVEdie/GOGOT/scripts/UIScalable.gd
@@ -24,3 +24,4 @@ func _ready() -> void:
 func update_ui_scale(scale: float) -> void:
     custom_minimum_size = SC_base_size_IN * scale
     add_theme_font_size_override("font_size", int(SC_base_font_IN * scale))
+    update_minimum_size()


### PR DESCRIPTION
## Summary
- update `UIScalable.gd` to refresh minimum sizes when scale changes

## Testing
- `godot --headless --editor --import --quit --path LIVEdie/GOGOT --quiet`
- `godot --headless --check-only --quit --path LIVEdie/GOGOT --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --nologo`
- `dotnet format BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --verify-no-changes --severity info`

------
https://chatgpt.com/codex/tasks/task_e_6872b91f96a48329b9a0384ea4d25b86