### PR TITLE
Fix RNGManager signal disconnect

### DIFF
--- a/LIVEdie/GOGOT/scripts/RNGManager.gd
+++ b/LIVEdie/GOGOT/scripts/RNGManager.gd
@@ -51,4 +51,4 @@ func _on_HTTPRequest_request_completed(
         var hex_seed := body.get_string_from_utf8().strip_edges()
         if hex_seed != "":
             RM_rng_IN.seed = int("0x" + hex_seed)
-    RM_http_request_IN.disconnect("request_completed", _on_HTTPRequest_request_completed)
+    RM_http_request_IN.request_completed.disconnect(_on_HTTPRequest_request_completed)


### PR DESCRIPTION
## Summary
- update disconnect syntax for `HTTPRequest` signal in RNGManager

## Testing
- `gdlint LIVEdie/GOGOT/scripts/RNGManager.gd`
- `godot --headless --editor --import --quit --path . --quiet`
- `godot --headless --check-only --quit --path . --quiet`
- `dotnet build BOIDFIsh/prototypes/softbody_fish/SoftBodyFish.sln --no-restore --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6873422e3b888329aaf8334eed73329e